### PR TITLE
CI: apply semver rules to ABI compatibility check

### DIFF
--- a/.github/scripts/abi_check.sh
+++ b/.github/scripts/abi_check.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Semver-aware ABI compatibility check using abidiff.
 #
 # Usage: abi_check.sh <baseline_lib> <current_lib> <baseline_version> <current_version>
 #
-# abidiff exit code bitmask:
+# abidiff exit code bitmask (values are OR'd; multiple bits can be set simultaneously):
 #   0  = no change
 #   1  = abidiff error
 #   2  = abidiff usage error
@@ -17,10 +17,10 @@
 
 set -e
 
-BASELINE_LIB=$1
-CURRENT_LIB=$2
-BASELINE_VERSION=$3
-CURRENT_VERSION=$4
+BASELINE_LIB=${1:?missing arg 1: baseline_lib}
+CURRENT_LIB=${2:?missing arg 2: current_lib}
+BASELINE_VERSION=${3:?missing arg 3: baseline_version}
+CURRENT_VERSION=${4:?missing arg 4: current_version}
 
 BASELINE_MAJOR=$(echo "$BASELINE_VERSION" | cut -d. -f1)
 BASELINE_MINOR=$(echo "$BASELINE_VERSION" | cut -d. -f2)
@@ -56,8 +56,12 @@ if [ "$HAS_INCOMPATIBLE" -ne 0 ]; then
     exit 1
 fi
 
-if [ "$CURRENT_MAJOR" -gt "$BASELINE_MAJOR" ] || [ "$CURRENT_MINOR" -gt "$BASELINE_MINOR" ]; then
-    echo "Version bump ($BASELINE_VERSION -> $CURRENT_VERSION): compatible ABI changes are allowed."
+if [ "$CURRENT_MAJOR" -gt "$BASELINE_MAJOR" ]; then
+    echo "Major version bump ($BASELINE_VERSION -> $CURRENT_VERSION): compatible ABI changes are allowed."
+    exit 0
+fi
+if [ "$CURRENT_MAJOR" -eq "$BASELINE_MAJOR" ] && [ "$CURRENT_MINOR" -gt "$BASELINE_MINOR" ]; then
+    echo "Minor version bump ($BASELINE_VERSION -> $CURRENT_VERSION): compatible ABI changes are allowed."
     exit 0
 fi
 

--- a/.github/scripts/abi_check.sh
+++ b/.github/scripts/abi_check.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Semver-aware ABI compatibility check using abidiff.
+#
+# Usage: abi_check.sh <baseline_lib> <current_lib> <baseline_version> <current_version>
+#
+# abidiff exit code bitmask:
+#   0  = no change
+#   1  = abidiff error
+#   2  = abidiff usage error
+#   4  = ABI change (compatible, e.g. added symbols)
+#   8  = ABI incompatible change (e.g. removed/changed symbols)
+#
+# Semver rules applied:
+#   patch bump : no ABI changes allowed
+#   minor bump : compatible additions allowed, incompatible changes not allowed
+#   major bump : all ABI changes allowed (breaking changes are expected)
+
+set -e
+
+BASELINE_LIB=$1
+CURRENT_LIB=$2
+BASELINE_VERSION=$3
+CURRENT_VERSION=$4
+
+BASELINE_MAJOR=$(echo "$BASELINE_VERSION" | cut -d. -f1)
+BASELINE_MINOR=$(echo "$BASELINE_VERSION" | cut -d. -f2)
+CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+CURRENT_MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+
+echo "Baseline version: $BASELINE_VERSION"
+echo "Current version:  $CURRENT_VERSION"
+
+ABIDIFF_EXIT=0
+abidiff "$BASELINE_LIB" "$CURRENT_LIB" || ABIDIFF_EXIT=$?
+
+HAS_CHANGE=$(( ABIDIFF_EXIT & 4 ))
+HAS_INCOMPATIBLE=$(( ABIDIFF_EXIT & 8 ))
+HAS_ERROR=$(( ABIDIFF_EXIT & ~12 ))
+
+if [ "$HAS_ERROR" -ne 0 ]; then
+    echo "abidiff encountered an error (exit code: $ABIDIFF_EXIT)"
+    exit 1
+fi
+
+if [ "$HAS_CHANGE" -eq 0 ] && [ "$HAS_INCOMPATIBLE" -eq 0 ]; then
+    echo "No ABI changes detected."
+    exit 0
+fi
+
+if [ "$HAS_INCOMPATIBLE" -ne 0 ]; then
+    if [ "$CURRENT_MAJOR" -gt "$BASELINE_MAJOR" ]; then
+        echo "Major version bump ($BASELINE_VERSION -> $CURRENT_VERSION): incompatible ABI changes are allowed."
+        exit 0
+    fi
+    echo "Incompatible ABI change detected without a major version bump."
+    exit 1
+fi
+
+if [ "$CURRENT_MAJOR" -gt "$BASELINE_MAJOR" ] || [ "$CURRENT_MINOR" -gt "$BASELINE_MINOR" ]; then
+    echo "Version bump ($BASELINE_VERSION -> $CURRENT_VERSION): compatible ABI changes are allowed."
+    exit 0
+fi
+
+echo "Compatible ABI change detected without a minor version bump."
+exit 1

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -59,12 +59,11 @@ jobs:
 
       - name: Run abidiff
         run: |
-          # abidiff returns non-zero if ABI changes are detected.
-          # The exit code is a bitmask: 0 = no change, 1 = compatible change, 2 = incompatible change, etc.
-          # We want to fail if there are any incompatible changes (bit 8 or higher, as per docs, or general non-zero for any change)
-          abidiff \
+          bash current/.github/scripts/abi_check.sh \
             baseline/build/shared/libmutiny.so \
-            current/build/shared/libmutiny.so
+            current/build/shared/libmutiny.so \
+            "$(cat baseline/cfg/VERSION)" \
+            "$(cat current/cfg/VERSION)"
 
 
   build:


### PR DESCRIPTION
## Description
The ABI Compatibility Check was failing whenever any ABI change was detected, regardless of whether the `VERSION` had been bumped appropriately. This extracts the check logic into `.github/scripts/abi_check.sh` and applies semver rules:

- **Patch bump**: no ABI changes allowed
- **Minor bump**: compatible additions (added symbols) are allowed; incompatible changes fail
- **Major bump**: all ABI changes are allowed

## Related Issues
Fixes #41

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MUTINY_` guards, `mutiny_` C-prefix).
- [ ] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.