### PR TITLE
Fix FE_INEXACT test on ARM: use float arithmetic to engage hardware FPU

### DIFF
--- a/examples/tests/FEDemo.test.cpp
+++ b/examples/tests/FEDemo.test.cpp
@@ -48,8 +48,8 @@ EXPECT_FAIL_TEST(FEDemo, should_fail_when_FE_OVERFLOW_is_set)
 EXPECT_FAIL_TEST(FEDemo, should_fail_when_FE_INEXACT_is_set)
 {
   IEEE754ExceptionsPlugin::enable_inexact();
-  volatile double f = 10.0;
-  CHECK_APPROX(f / 3.0, 3.333, 0.001);
+  volatile float f = 10.0f;
+  CHECK_APPROX(f / 3.0f, 3.333f, 0.001f);
 }
 
 TEST(FEDemo, should_succeed_when_no_flags_are_set)


### PR DESCRIPTION
## Description

`EXPECT_FAIL_TEST(FEDemo, should_fail_when_FE_INEXACT_is_set)` was passing on the GCC ARM embedded build instead of failing as expected. The test relies on the IEEE754ExceptionsPlugin detecting that `FE_INEXACT` was raised after a division.

The Cortex-M4 FPU (`fpv4-sp-d16`) is **single-precision only**. Commit b3d077e0 changed the test from `volatile float` to `volatile double`, which caused the division to be computed via soft-FP emulation. Soft-FP routines do not update the hardware `fenv` exception flags, so `FE_INEXACT` was never raised, the plugin had nothing to catch, and the test passed when it should have failed.

Reverts the arithmetic back to `float` so the division goes through the hardware FPU and raises `FE_INEXACT`.

## Related Issues

Fixes # (issue number)

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Manual Verification (Optional)
- **Target:** Cortex-M4 via QEMU (`qemu-arm-static -cpu cortex-m4`) in CI
- **Result:** Expected — CI will verify

## Checklist
- [ ] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MUTINY_` guards, `mutiny_` C-prefix).
- [ ] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.