### PR TITLE
Templatize ApproxEqualFailure and assert_approx_equal

### DIFF
--- a/include/mutiny/test/Failure.hpp
+++ b/include/mutiny/test/Failure.hpp
@@ -208,6 +208,24 @@ public:
       double threshold,
       const String& text
   );
+  /**
+   * @param test         The failing test.
+   * @param file_name    Source file of the assertion.
+   * @param line_number  Line of the assertion.
+   * @param expected     Expected float value.
+   * @param actual       Actual float value.
+   * @param threshold    Allowed tolerance.
+   * @param text         Optional user text.
+   */
+  ApproxEqualFailure(
+      Shell* test,
+      const char* file_name,
+      size_t line_number,
+      float expected,
+      float actual,
+      float threshold,
+      const String& text
+  );
 };
 
 /**

--- a/include/mutiny/test/Failure.hpp
+++ b/include/mutiny/test/Failure.hpp
@@ -217,7 +217,8 @@ public:
     : Failure(test, file_name, line_number)
   {
     message_ = create_user_text(text);
-    message_ += create_but_was_string(string_from(expected), string_from(actual));
+    message_ +=
+        create_but_was_string(string_from(expected), string_from(actual));
     message_ += " threshold used was <";
     message_ += string_from(threshold);
     message_ += ">";

--- a/include/mutiny/test/Failure.hpp
+++ b/include/mutiny/test/Failure.hpp
@@ -186,16 +186,22 @@ public:
 /**
  * @brief Failure for @ref CHECK_APPROX when two values differ by more than
  * the threshold.
+ *
+ * @tparam T  Numeric type of the values (@c int, @c float, @c double, etc.).
+ *            Values are formatted via @ref mu::tiny::string_from() and NaN is
+ *            detected with the IEEE 754 self-comparison trick (@c v!=v), the
+ *            same approach used by @ref mu::tiny::test::approx_equal.
  */
-class MUTINY_EXPORT ApproxEqualFailure : public Failure
+template<typename T>
+class ApproxEqualFailure : public Failure
 {
 public:
   /**
    * @param test         The failing test.
    * @param file_name    Source file of the assertion.
    * @param line_number  Line of the assertion.
-   * @param expected     Expected double value.
-   * @param actual       Actual double value.
+   * @param expected     Expected value.
+   * @param actual       Actual value.
    * @param threshold    Allowed tolerance.
    * @param text         Optional user text.
    */
@@ -203,29 +209,22 @@ public:
       Shell* test,
       const char* file_name,
       size_t line_number,
-      double expected,
-      double actual,
-      double threshold,
+      T expected,
+      T actual,
+      T threshold,
       const String& text
-  );
-  /**
-   * @param test         The failing test.
-   * @param file_name    Source file of the assertion.
-   * @param line_number  Line of the assertion.
-   * @param expected     Expected float value.
-   * @param actual       Actual float value.
-   * @param threshold    Allowed tolerance.
-   * @param text         Optional user text.
-   */
-  ApproxEqualFailure(
-      Shell* test,
-      const char* file_name,
-      size_t line_number,
-      float expected,
-      float actual,
-      float threshold,
-      const String& text
-  );
+  )
+    : Failure(test, file_name, line_number)
+  {
+    message_ = create_user_text(text);
+    message_ += create_but_was_string(string_from(expected), string_from(actual));
+    message_ += " threshold used was <";
+    message_ += string_from(threshold);
+    message_ += ">";
+    // v != v is true iff v is NaN (IEEE 754); always false for integral T
+    if (expected != expected || actual != actual || threshold != threshold)
+      message_ += "\n\tCannot make comparisons with Nan";
+  }
 };
 
 /**

--- a/include/mutiny/test/Shell.hpp
+++ b/include/mutiny/test/Shell.hpp
@@ -11,6 +11,7 @@
 #ifndef INCLUDED_MUTINY_TEST_SHELL_HPP
 #define INCLUDED_MUTINY_TEST_SHELL_HPP
 
+#include "mutiny/test/Failure.hpp"
 #include "mutiny/test/Terminator.hpp"
 
 #include "mutiny/String.hpp"
@@ -246,26 +247,27 @@ public:
       size_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
-  /** @brief Macro backend: assert two doubles are equal within @p threshold. */
-  virtual void assert_approx_equal(
-      double expected,
-      double actual,
-      double threshold,
+  /**
+   * @brief Macro backend: assert two values are equal within @p threshold.
+   *
+   * @tparam T  Numeric type; must have a @ref mu::tiny::string_from() overload.
+   */
+  template<typename T>
+  void assert_approx_equal(
+      T expected,
+      T actual,
+      T threshold,
       const char* text,
       const char* file_name,
       size_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
-  );
-  /** @brief Macro backend: assert two floats are equal within @p threshold. */
-  virtual void assert_approx_equal(
-      float expected,
-      float actual,
-      float threshold,
-      const char* text,
-      const char* file_name,
-      size_t line_number,
-      const Terminator& test_terminator = get_current_test_terminator()
-  );
+  )
+  {
+    add_failure(
+        ApproxEqualFailure<T>(this, file_name, line_number, expected, actual, threshold, text)
+    );
+    test_terminator.exit_current_test();
+  }
   /** @brief Macro backend: generic equality failure with pre-formatted strings.
    */
   virtual void assert_equals(
@@ -541,48 +543,6 @@ void check_enum_equal(
 }
 
 /**
- * @brief Failure-reporting dispatch for @ref check_approx.
- *
- * Primary template: casts @p T to @c double so that integral types produce an
- * unambiguous overload call and the conversion is explicit rather than silent.
- * Explicitly specialised for @c float (see below) to avoid promoting float
- * values to double.
- */
-template<typename T>
-void check_approx_fail(
-    T expected,
-    T actual,
-    T threshold,
-    const char* text,
-    const char* file,
-    size_t line
-)
-{
-  Shell::get_current()->assert_approx_equal(
-      static_cast<double>(expected),
-      static_cast<double>(actual),
-      static_cast<double>(threshold),
-      text,
-      file,
-      line
-  );
-}
-
-/** @brief @c float specialisation: passes values as @c float, no promotion. */
-template<>
-inline void check_approx_fail<float>(
-    float expected,
-    float actual,
-    float threshold,
-    const char* text,
-    const char* file,
-    size_t line
-)
-{
-  Shell::get_current()->assert_approx_equal(expected, actual, threshold, text, file, line);
-}
-
-/**
  * @brief Implementation helper for CHECK_APPROX.
  *
  * All three operands share the same type @p T so mismatched-type calls produce
@@ -607,7 +567,7 @@ void check_approx(
 )
 {
   if (!approx_equal(expected, actual, threshold)) {
-    check_approx_fail(expected, actual, threshold, text, file, line);
+    Shell::get_current()->assert_approx_equal(expected, actual, threshold, text, file, line);
   } else {
     Shell::get_current()->count_check();
   }

--- a/include/mutiny/test/Shell.hpp
+++ b/include/mutiny/test/Shell.hpp
@@ -256,6 +256,16 @@ public:
       size_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
+  /** @brief Macro backend: assert two floats are equal within @p threshold. */
+  virtual void assert_approx_equal(
+      float expected,
+      float actual,
+      float threshold,
+      const char* text,
+      const char* file_name,
+      size_t line_number,
+      const Terminator& test_terminator = get_current_test_terminator()
+  );
   /** @brief Macro backend: generic equality failure with pre-formatted strings.
    */
   virtual void assert_equals(
@@ -531,6 +541,48 @@ void check_enum_equal(
 }
 
 /**
+ * @brief Failure-reporting dispatch for @ref check_approx.
+ *
+ * Primary template: casts @p T to @c double so that integral types produce an
+ * unambiguous overload call and the conversion is explicit rather than silent.
+ * Explicitly specialised for @c float (see below) to avoid promoting float
+ * values to double.
+ */
+template<typename T>
+void check_approx_fail(
+    T expected,
+    T actual,
+    T threshold,
+    const char* text,
+    const char* file,
+    size_t line
+)
+{
+  Shell::get_current()->assert_approx_equal(
+      static_cast<double>(expected),
+      static_cast<double>(actual),
+      static_cast<double>(threshold),
+      text,
+      file,
+      line
+  );
+}
+
+/** @brief @c float specialisation: passes values as @c float, no promotion. */
+template<>
+inline void check_approx_fail<float>(
+    float expected,
+    float actual,
+    float threshold,
+    const char* text,
+    const char* file,
+    size_t line
+)
+{
+  Shell::get_current()->assert_approx_equal(expected, actual, threshold, text, file, line);
+}
+
+/**
  * @brief Implementation helper for CHECK_APPROX.
  *
  * All three operands share the same type @p T so mismatched-type calls produce
@@ -555,9 +607,7 @@ void check_approx(
 )
 {
   if (!approx_equal(expected, actual, threshold)) {
-    Shell::get_current()->assert_approx_equal(
-        expected, actual, threshold, text, file, line
-    );
+    check_approx_fail(expected, actual, threshold, text, file, line);
   } else {
     Shell::get_current()->count_check();
   }

--- a/include/mutiny/test/Shell.hpp
+++ b/include/mutiny/test/Shell.hpp
@@ -264,7 +264,9 @@ public:
   )
   {
     add_failure(
-        ApproxEqualFailure<T>(this, file_name, line_number, expected, actual, threshold, text)
+        ApproxEqualFailure<T>(
+            this, file_name, line_number, expected, actual, threshold, text
+        )
     );
     test_terminator.exit_current_test();
   }
@@ -567,7 +569,9 @@ void check_approx(
 )
 {
   if (!approx_equal(expected, actual, threshold)) {
-    Shell::get_current()->assert_approx_equal(expected, actual, threshold, text, file, line);
+    Shell::get_current()->assert_approx_equal(
+        expected, actual, threshold, text, file, line
+    );
   } else {
     Shell::get_current()->count_check();
   }

--- a/src/test/Failure.cpp
+++ b/src/test/Failure.cpp
@@ -285,6 +285,29 @@ ApproxEqualFailure::ApproxEqualFailure(
     message_ += "\n\tCannot make comparisons with Nan";
 }
 
+ApproxEqualFailure::ApproxEqualFailure(
+    Shell* test,
+    const char* file_name,
+    size_t line_number,
+    float expected,
+    float actual,
+    float threshold,
+    const String& text
+)
+  : Failure(test, file_name, line_number)
+{
+  message_ = create_user_text(text);
+
+  message_ +=
+      create_but_was_string(string_from(expected, 7), string_from(actual, 7));
+  message_ += " threshold used was <";
+  message_ += string_from(threshold, 7);
+  message_ += ">";
+
+  if (is_nan(expected) || is_nan(actual) || is_nan(threshold))
+    message_ += "\n\tCannot make comparisons with Nan";
+}
+
 CheckEqualFailure::CheckEqualFailure(
     Shell* test,
     const char* file_name,

--- a/src/test/Failure.cpp
+++ b/src/test/Failure.cpp
@@ -4,7 +4,6 @@
 #include "mutiny/test/Shell.hpp"
 
 #include "mutiny/String.hpp"
-#include "mutiny/math.hpp"
 
 #if MUTINY_USE_STD_CPP_LIB
 #include <typeinfo>
@@ -262,51 +261,6 @@ EqualsFailure::EqualsFailure(
   message_ += create_but_was_string(expected, actual);
 }
 
-ApproxEqualFailure::ApproxEqualFailure(
-    Shell* test,
-    const char* file_name,
-    size_t line_number,
-    double expected,
-    double actual,
-    double threshold,
-    const String& text
-)
-  : Failure(test, file_name, line_number)
-{
-  message_ = create_user_text(text);
-
-  message_ +=
-      create_but_was_string(string_from(expected, 7), string_from(actual, 7));
-  message_ += " threshold used was <";
-  message_ += string_from(threshold, 7);
-  message_ += ">";
-
-  if (is_nan(expected) || is_nan(actual) || is_nan(threshold))
-    message_ += "\n\tCannot make comparisons with Nan";
-}
-
-ApproxEqualFailure::ApproxEqualFailure(
-    Shell* test,
-    const char* file_name,
-    size_t line_number,
-    float expected,
-    float actual,
-    float threshold,
-    const String& text
-)
-  : Failure(test, file_name, line_number)
-{
-  message_ = create_user_text(text);
-
-  message_ +=
-      create_but_was_string(string_from(expected, 7), string_from(actual, 7));
-  message_ += " threshold used was <";
-  message_ += string_from(threshold, 7);
-  message_ += ">";
-
-  if (is_nan(expected) || is_nan(actual) || is_nan(threshold))
-    message_ += "\n\tCannot make comparisons with Nan";
-}
 
 CheckEqualFailure::CheckEqualFailure(
     Shell* test,

--- a/src/test/Failure.cpp
+++ b/src/test/Failure.cpp
@@ -261,7 +261,6 @@ EqualsFailure::EqualsFailure(
   message_ += create_but_was_string(expected, actual);
 }
 
-
 CheckEqualFailure::CheckEqualFailure(
     Shell* test,
     const char* file_name,

--- a/src/test/Shell.cpp
+++ b/src/test/Shell.cpp
@@ -537,6 +537,22 @@ void Shell::assert_approx_equal(
   test_terminator.exit_current_test();
 }
 
+void Shell::assert_approx_equal(
+    float expected,
+    float actual,
+    float threshold,
+    const char* text,
+    const char* file_name,
+    size_t line_number,
+    const Terminator& test_terminator
+)
+{
+  add_failure(ApproxEqualFailure(
+      this, file_name, line_number, expected, actual, threshold, text
+  ));
+  test_terminator.exit_current_test();
+}
+
 void Shell::assert_binary_equal(
     const void* expected,
     const void* actual,

--- a/src/test/Shell.cpp
+++ b/src/test/Shell.cpp
@@ -521,7 +521,6 @@ void Shell::assert_pointers_equal(
   }
 }
 
-
 void Shell::assert_binary_equal(
     const void* expected,
     const void* actual,

--- a/src/test/Shell.cpp
+++ b/src/test/Shell.cpp
@@ -521,37 +521,6 @@ void Shell::assert_pointers_equal(
   }
 }
 
-void Shell::assert_approx_equal(
-    double expected,
-    double actual,
-    double threshold,
-    const char* text,
-    const char* file_name,
-    size_t line_number,
-    const Terminator& test_terminator
-)
-{
-  add_failure(ApproxEqualFailure(
-      this, file_name, line_number, expected, actual, threshold, text
-  ));
-  test_terminator.exit_current_test();
-}
-
-void Shell::assert_approx_equal(
-    float expected,
-    float actual,
-    float threshold,
-    const char* text,
-    const char* file_name,
-    size_t line_number,
-    const Terminator& test_terminator
-)
-{
-  add_failure(ApproxEqualFailure(
-      this, file_name, line_number, expected, actual, threshold, text
-  ));
-  test_terminator.exit_current_test();
-}
 
 void Shell::assert_binary_equal(
     const void* expected,

--- a/tests/integration/TestFailure.test.cpp
+++ b/tests/integration/TestFailure.test.cpp
@@ -380,7 +380,7 @@ TEST(Failure, StringsEqualNoCaseFailure2)
 
 TEST(Failure, DoublesEqualNormalWithText)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<double> f(
       test, fail_file_name, fail_line_number, 1.0, 2.0, 3.0, "text"
   );
   FAILURE_EQUAL(
@@ -393,7 +393,7 @@ TEST(Failure, DoublesEqualNormalWithText)
 
 TEST(Failure, DoublesEqualNormal)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<double> f(
       test, fail_file_name, fail_line_number, 1.0, 2.0, 3.0, ""
   );
   FAILURE_EQUAL(

--- a/tests/integration/TestFailureNaN.test.cpp
+++ b/tests/integration/TestFailureNaN.test.cpp
@@ -28,7 +28,7 @@ TEST_GROUP(TestFailureNaN)
 
 TEST(TestFailureNaN, DoublesEqualExpectedIsNaN)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<double> f(
       test,
       fail_file_name,
       fail_line_number,
@@ -47,7 +47,7 @@ TEST(TestFailureNaN, DoublesEqualExpectedIsNaN)
 
 TEST(TestFailureNaN, DoublesEqualActualIsNaN)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<double> f(
       test,
       fail_file_name,
       fail_line_number,
@@ -66,7 +66,7 @@ TEST(TestFailureNaN, DoublesEqualActualIsNaN)
 
 TEST(TestFailureNaN, DoublesEqualThresholdIsNaN)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<double> f(
       test,
       fail_file_name,
       fail_line_number,
@@ -85,7 +85,7 @@ TEST(TestFailureNaN, DoublesEqualThresholdIsNaN)
 
 TEST(TestFailureNaN, DoublesEqualExpectedIsInf)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<double> f(
       test,
       fail_file_name,
       fail_line_number,
@@ -103,7 +103,7 @@ TEST(TestFailureNaN, DoublesEqualExpectedIsInf)
 
 TEST(TestFailureNaN, DoublesEqualActualIsInf)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<double> f(
       test,
       fail_file_name,
       fail_line_number,
@@ -121,7 +121,7 @@ TEST(TestFailureNaN, DoublesEqualActualIsInf)
 
 TEST(TestFailureNaN, DoublesEqualThresholdIsInf)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<double> f(
       test,
       fail_file_name,
       fail_line_number,
@@ -140,7 +140,7 @@ TEST(TestFailureNaN, DoublesEqualThresholdIsInf)
 
 TEST(TestFailureNaN, FloatsEqualExpectedIsNaN)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<float> f(
       test,
       fail_file_name,
       fail_line_number,
@@ -159,7 +159,7 @@ TEST(TestFailureNaN, FloatsEqualExpectedIsNaN)
 
 TEST(TestFailureNaN, FloatsEqualActualIsNaN)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<float> f(
       test,
       fail_file_name,
       fail_line_number,
@@ -178,7 +178,7 @@ TEST(TestFailureNaN, FloatsEqualActualIsNaN)
 
 TEST(TestFailureNaN, FloatsEqualThresholdIsNaN)
 {
-  mu::tiny::test::ApproxEqualFailure f(
+  mu::tiny::test::ApproxEqualFailure<float> f(
       test,
       fail_file_name,
       fail_line_number,

--- a/tests/integration/TestFailureNaN.test.cpp
+++ b/tests/integration/TestFailureNaN.test.cpp
@@ -138,4 +138,61 @@ TEST(TestFailureNaN, DoublesEqualThresholdIsInf)
   );
 }
 
+TEST(TestFailureNaN, FloatsEqualExpectedIsNaN)
+{
+  mu::tiny::test::ApproxEqualFailure f(
+      test,
+      fail_file_name,
+      fail_line_number,
+      static_cast<float>(NAN),
+      2.0f,
+      3.0f,
+      ""
+  );
+  FAILURE_EQUAL(
+      "expected <Nan - Not a number>\n"
+      "\tbut was  <2> threshold used was <3>\n"
+      "\tCannot make comparisons with Nan",
+      f
+  );
+}
+
+TEST(TestFailureNaN, FloatsEqualActualIsNaN)
+{
+  mu::tiny::test::ApproxEqualFailure f(
+      test,
+      fail_file_name,
+      fail_line_number,
+      1.0f,
+      static_cast<float>(NAN),
+      3.0f,
+      ""
+  );
+  FAILURE_EQUAL(
+      "expected <1>\n"
+      "\tbut was  <Nan - Not a number> threshold used was <3>\n"
+      "\tCannot make comparisons with Nan",
+      f
+  );
+}
+
+TEST(TestFailureNaN, FloatsEqualThresholdIsNaN)
+{
+  mu::tiny::test::ApproxEqualFailure f(
+      test,
+      fail_file_name,
+      fail_line_number,
+      1.0f,
+      2.0f,
+      static_cast<float>(NAN),
+      ""
+  );
+  FAILURE_EQUAL(
+      "expected <1>\n"
+      "\tbut was  <2> threshold used was <Nan - Not a number>\n"
+      "\tCannot make comparisons with Nan",
+      f
+  );
+}
+
 #endif

--- a/tests/integration/TestShellMacros.test.cpp
+++ b/tests/integration/TestShellMacros.test.cpp
@@ -139,6 +139,12 @@ void failing_test_method_with_check_equal_function_pointer_text()
   mu::tiny::test::TestingFixture::line_executed_after_check();
 }
 
+void failing_test_method_with_check_equal_float()
+{
+  CHECK_EQUAL(1.5f, 2.5f);
+  mu::tiny::test::TestingFixture::line_executed_after_check();
+}
+
 void failing_test_method_with_check_approx()
 {
   CHECK_APPROX(0.12, 44.1, 0.3);
@@ -190,6 +196,7 @@ int function_that_returns_a_value()
   STRCMP_EQUAL("THIS", "THIS");
   STRCMP_EQUAL_TEXT("THIS", "THIS", "Shouldn't fail");
   CHECK_COMPARE(1, <, 2);
+  CHECK_EQUAL(1.0f, 1.0f);
   CHECK_APPROX(1.0, 1.0, .01);
   CHECK_APPROX_TEXT(1.0, 1.0, .01, "Shouldn't fail");
   CHECK_APPROX(1.0f, 1.0f, .01f);
@@ -482,6 +489,13 @@ TEST(TestShellMacros, FailureWithCHECK_EQUAL_FunctionPointerText)
   CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0xa5a5>");
   CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0xf0f0>");
   CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(TestShellMacros, FailureWithCHECK_EQUAL_Float)
+{
+  fixture.run_test_with_method(failing_test_method_with_check_equal_float);
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1.5>");
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <2.5>");
 }
 
 TEST(TestShellMacros, FailureWithCHECK_APPROX)

--- a/tests/integration/TestShellMacros.test.cpp
+++ b/tests/integration/TestShellMacros.test.cpp
@@ -169,6 +169,27 @@ void failing_test_method_with_check_approx_int()
   mu::tiny::test::TestingFixture::line_executed_after_check();
 }
 
+// actual < expected: exercises the d2 - d1 branch in approx_equal
+void failing_test_method_with_check_approx_int_reversed()
+{
+  CHECK_APPROX(1020, 1000, 10);
+  mu::tiny::test::TestingFixture::line_executed_after_check();
+}
+
+// unsigned: actual < expected — guards against unsigned wrap-around
+void failing_test_method_with_check_approx_unsigned()
+{
+  CHECK_APPROX(5u, 3u, 1u);
+  mu::tiny::test::TestingFixture::line_executed_after_check();
+}
+
+// signed integers spanning zero
+void failing_test_method_with_check_approx_negative()
+{
+  CHECK_APPROX(-10, 10, 5);
+  mu::tiny::test::TestingFixture::line_executed_after_check();
+}
+
 bool line_of_code_executed_after_check = false;
 
 void passing_test_method()
@@ -201,6 +222,8 @@ int function_that_returns_a_value()
   CHECK_APPROX_TEXT(1.0, 1.0, .01, "Shouldn't fail");
   CHECK_APPROX(1.0f, 1.0f, .01f);
   CHECK_APPROX(1000, 1000, 10);
+  CHECK_APPROX(1000, 1010, 10); // exactly at threshold — must pass
+  CHECK_APPROX(5u, 5u, 1u);     // unsigned pass
   CHECK_EQUAL(nullptr, nullptr);
   CHECK_EQUAL_TEXT(nullptr, nullptr, "Shouldn't fail");
   MEMCMP_EQUAL("THIS", "THIS", 5);
@@ -529,6 +552,32 @@ TEST(TestShellMacros, FailureWithCHECK_APPROXInt)
   CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1000>");
   CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <1020>");
   CHECK_TEST_FAILS_PROPER_WITH_TEXT("threshold used was <10>");
+}
+
+TEST(TestShellMacros, FailureWithCHECK_APPROXIntReversed)
+{
+  fixture.run_test_with_method(
+      failing_test_method_with_check_approx_int_reversed
+  );
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1020>");
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <1000>");
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("threshold used was <10>");
+}
+
+TEST(TestShellMacros, FailureWithCHECK_APPROXUnsigned)
+{
+  fixture.run_test_with_method(failing_test_method_with_check_approx_unsigned);
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <5>");
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <3>");
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("threshold used was <1>");
+}
+
+TEST(TestShellMacros, FailureWithCHECK_APPROXNegative)
+{
+  fixture.run_test_with_method(failing_test_method_with_check_approx_negative);
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <-10>");
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <10>");
+  CHECK_TEST_FAILS_PROPER_WITH_TEXT("threshold used was <5>");
 }
 
 TEST(TestShellMacros, SuccessPrintsNothing)


### PR DESCRIPTION
## Description

`CHECK_APPROX(1.0f, 1.5f, 0.1f)` was silently promoting all three `float` values to `double` on the failure-reporting path (passed to `assert_approx_equal(double, double, double)`). Similarly, `CHECK_APPROX(110, 111, 10)` was casting integers to `double`. This PR fixes the root cause by making the failure type itself generic.

**`ApproxEqualFailure<T>`** is now a class template. Its constructor:
- formats values via `string_from(T)` (type-correct for `int`, `float`, `double`, etc.)
- detects NaN using the IEEE 754 self-comparison trick (`v != v`), the same approach already used in `approx_equal<T>`
- carries no `double` anywhere in its interface

**`Shell::assert_approx_equal`** becomes a non-virtual template method that constructs `ApproxEqualFailure<T>` directly. The virtual seam for observing failures is `add_failure`, as with every other assertion.

**`check_approx<T>`** now passes its `T` values straight through — no cast, no dispatch helper, no overload ambiguity.

As a secondary change, `CHECK_EQUAL` with `float` is explicitly covered by a passing test and a failing-message test (it was already correct, but untested).

## Related Issues

Fixes # (issue number)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MUTINY_` guards, `mutiny_` C-prefix).
- [x] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.