### PR TITLE
Add versioned documentation deployment to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,15 +27,21 @@ jobs:
         id: ref
         run: |
           if [[ -n "${{ github.event.inputs.tag }}" ]]; then
-            echo "ref=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
-            echo "slug=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+            TAG="${{ github.event.inputs.tag }}"
+            SLUG="$(echo "$TAG" | sed 's/^v//; s/\.[0-9]*$//')"
+            echo "ref=$TAG" >> "$GITHUB_OUTPUT"
+            echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+            echo "github_ref=$TAG" >> "$GITHUB_OUTPUT"
           elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
+            SLUG="$(echo "$TAG" | sed 's/^v//; s/\.[0-9]*$//')"
             echo "ref=$TAG" >> "$GITHUB_OUTPUT"
-            echo "slug=$TAG" >> "$GITHUB_OUTPUT"
+            echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+            echo "github_ref=$TAG" >> "$GITHUB_OUTPUT"
           else
             echo "ref=main" >> "$GITHUB_OUTPUT"
             echo "slug=main" >> "$GITHUB_OUTPUT"
+            echo "github_ref=main" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@v6
@@ -57,7 +63,7 @@ jobs:
       - name: Build documentation
         run: uv run --project docs make -C docs html
         env:
-          DOCS_GITHUB_REF: ${{ steps.ref.outputs.slug }}
+          DOCS_GITHUB_REF: ${{ steps.ref.outputs.github_ref }}
 
       - name: Prepare gh-pages worktree
         run: |
@@ -79,10 +85,10 @@ jobs:
       - name: Update versions.json and root files
         run: |
           cd _gh-pages
-          # Build versions.json: main first, then tags in reverse version order.
+          # Build versions.json: main first, then major.minor dirs newest-first.
           (
             [ -d main ] && jq -n '{"version":"main","url":"main/"}'
-            for d in $(ls -d v[0-9]* 2>/dev/null | sort -Vr); do
+            for d in $(ls -d [0-9]*.[0-9]* 2>/dev/null | sort -Vr); do
               jq -n --arg v "$d" '{"version":$v,"url":($v+"/")}'
             done
           ) | jq -s '.' > versions.json

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,112 @@
+---
+name: Deploy Docs
+
+"on":
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build docs for (e.g. v0.1.0). Leave empty to build from the default branch."
+        required: false
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Build and Deploy Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine ref and version slug
+        id: ref
+        run: |
+          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+            echo "ref=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "slug=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            echo "ref=$TAG" >> "$GITHUB_OUTPUT"
+            echo "slug=$TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+            echo "slug=main" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: "3.14"
+
+      - name: Install Doxygen
+        uses: ssciwr/doxygen-install@v1
+        with:
+          version: "1.16.1"
+
+      - name: Build documentation
+        run: uv run --project docs make -C docs html
+        env:
+          DOCS_GITHUB_REF: ${{ steps.ref.outputs.slug }}
+
+      - name: Prepare gh-pages worktree
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch --depth 1 origin gh-pages:gh-pages 2>/dev/null || true
+          if git show-ref --verify refs/heads/gh-pages 2>/dev/null; then
+            git worktree add _gh-pages gh-pages
+          else
+            git worktree add --orphan -b gh-pages _gh-pages
+          fi
+
+      - name: Deploy version
+        run: |
+          SLUG="${{ steps.ref.outputs.slug }}"
+          rm -rf "_gh-pages/${SLUG}"
+          cp -r docs/_build/html "_gh-pages/${SLUG}"
+
+      - name: Update versions.json and root files
+        run: |
+          cd _gh-pages
+          # Build versions.json: main first, then tags in reverse version order.
+          (
+            [ -d main ] && jq -n '{"version":"main","url":"main/"}'
+            for d in $(ls -d v[0-9]* 2>/dev/null | sort -Vr); do
+              jq -n --arg v "$d" '{"version":$v,"url":($v+"/")}'
+            done
+          ) | jq -s '.' > versions.json
+
+          cat > index.html << 'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta http-equiv="refresh" content="0; url=main/">
+            <title>Redirecting to mutiny docs…</title>
+          </head>
+          <body>
+            <p><a href="main/">Click here</a> if you are not redirected.</p>
+          </body>
+          </html>
+          EOF
+
+          touch .nojekyll
+
+      - name: Commit and push
+        run: |
+          cd _gh-pages
+          git add -A
+          git diff --cached --quiet && exit 0
+          git commit -m "docs: deploy ${{ steps.ref.outputs.slug }}"
+          git push origin gh-pages

--- a/docs/_templates/.gitignore
+++ b/docs/_templates/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/docs/_templates/sidebar/version-switcher.html
+++ b/docs/_templates/sidebar/version-switcher.html
@@ -1,0 +1,69 @@
+<div class="sidebar-version-switcher">
+  <select
+    id="version-select"
+    aria-label="Select documentation version"
+    onchange="if(this.value) window.location.href=this.value;"
+  >
+    <option value="">Version: …</option>
+  </select>
+</div>
+<script>
+(function () {
+  // Derive the site root and current version slug from the URL.
+  // URL shape: /mutiny/<version>/path/to/page.html
+  //   parts[0] = ""
+  //   parts[1] = "mutiny"   (repo name / Pages base path)
+  //   parts[2] = "main" | "v0.1.0" | …
+  var parts = window.location.pathname.split("/");
+  var siteRoot = "/" + parts.slice(1, 2).join("/") + "/";  // e.g. "/mutiny/"
+  var currentSlug = parts[2] || "";                         // e.g. "main"
+  var versionsUrl = siteRoot + "versions.json";
+
+  fetch(versionsUrl)
+    .then(function (r) {
+      if (!r.ok) throw new Error("versions.json not found");
+      return r.json();
+    })
+    .then(function (versions) {
+      var sel = document.getElementById("version-select");
+      sel.innerHTML = "";
+      versions.forEach(function (v) {
+        var opt = document.createElement("option");
+        opt.value = siteRoot + v.url;
+        opt.textContent = v.version;
+        if (v.version === currentSlug) {
+          opt.selected = true;
+        }
+        sel.appendChild(opt);
+      });
+    })
+    .catch(function () {
+      // Not deployed (local build) — hide the switcher silently.
+      var wrapper = document.querySelector(".sidebar-version-switcher");
+      if (wrapper) wrapper.style.display = "none";
+    });
+})();
+</script>
+<style>
+.sidebar-version-switcher {
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--color-sidebar-item-background--hover);
+}
+
+.sidebar-version-switcher select {
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  background: var(--color-sidebar-item-background);
+  color: var(--color-sidebar-link-text);
+  border: 1px solid var(--color-sidebar-item-background--hover);
+  border-radius: 4px;
+  font-size: var(--font-size--small);
+  cursor: pointer;
+}
+
+.sidebar-version-switcher select:hover,
+.sidebar-version-switcher select:focus {
+  border-color: var(--color-brand-primary);
+  outline: none;
+}
+</style>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,4 @@
+import os
 import re
 import textwrap
 import xml.etree.ElementTree as ET
@@ -81,7 +82,7 @@ exhale_args = {
 # -- GitHub source links -------------------------------------------------------
 
 _github_root = "https://github.com/thetic/mutiny"
-_github_branch = "main"
+_github_branch = os.environ.get("DOCS_GITHUB_REF", "main")
 
 # :source:`filename <path/to/file>` → link into the GitHub tree
 extlinks = {
@@ -92,6 +93,7 @@ extlinks = {
 
 html_theme = "furo"
 html_static_path = ["_static"]
+templates_path = ["_templates"]
 html_title = "mutiny"
 html_logo = "_static/logo.png"
 html_theme_options = {
@@ -105,6 +107,17 @@ html_theme_options = {
             "html": '<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>',
             "class": "",
         },
+    ],
+}
+
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/version-switcher.html",
+        "sidebar/search.html",
+        "sidebar/scroll-start.html",
+        "sidebar/navigation.html",
+        "sidebar/scroll-end.html",
     ],
 }
 


### PR DESCRIPTION
## Description

Publishes Sphinx documentation to GitHub Pages at `thetic.github.io/mutiny` with a version selector dropdown for tagged releases.

## Related Issues

Fixes #30

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## What's included

**`.github/workflows/docs.yml`** — New deployment workflow triggered on:
- Push to `main` → deploys to `main/` on the `gh-pages` branch
- Push of a `v*` tag → deploys to `v<tag>/` on the `gh-pages` branch
- `workflow_dispatch` with an optional tag input → retroactive builds (e.g. `v0.1.0`)

Uses `git worktree` to avoid a second clone and `jq` to regenerate `versions.json` from deployed directories. Concurrency group `docs-deploy` with `cancel-in-progress: false` prevents race conditions when multiple triggers fire simultaneously.

**`docs/conf.py`**:
- `_github_branch` now reads from `DOCS_GITHUB_REF` env var (defaults to `"main"`) so source links in tagged builds point to the correct tag on GitHub rather than always pointing to `main`
- `templates_path` and `html_sidebars` added to wire in the version switcher

**`docs/_templates/sidebar/version-switcher.html`** — Furo sidebar fragment placed above the search box. Fetches `versions.json` at runtime and renders a `<select>` dropdown. Hides itself gracefully when `versions.json` is absent (local builds).

## After merging

1. Enable GitHub Pages in repo settings: **Source → Deploy from a branch → `gh-pages`, root `/`**
2. The merge to `main` will trigger the first deploy of `main/` docs automatically
3. Use **Actions → Deploy Docs → Run workflow** with tag `v0.1.0` to retroactively publish the existing release

## Checklist

- [x] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MUTINY_` guards, `mutiny_` C-prefix).
- [ ] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.