### PR TITLE
docs: add JUnit test results badge to README

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,7 +1,7 @@
 ---
 name: 'Test Report'
-# This workflow must live in a separate file and be triggered by 'workflow_run' 
-# to allow it to have 'write' permissions (for creating checks and PR comments) 
+# This workflow must live in a separate file and be triggered by 'workflow_run'
+# to allow it to have 'write' permissions (for creating checks and PR comments)
 # even when the triggering workflow ('Basic builds') is run from a fork.
 "on":
   workflow_run:
@@ -18,9 +18,30 @@ jobs:
     if: always()
     steps:
       - uses: dorny/test-reporter@v3
+        id: test-reporter
         with:
           artifact: test-results
           name: JUnit Tests
           path: "**/mutiny_*.xml"
           reporter: java-junit
           use-actions-summary: false
+
+      # Updates the dynamic badge in the README on every successful main run.
+      # One-time setup required:
+      #   1. Create a public Gist at https://gist.github.com (any content)
+      #   2. Replace YOUR_GIST_ID below (and in README.md) with the ID from the Gist URL
+      #   3. Create a classic PAT with 'gist' scope at https://github.com/settings/tokens
+      #   4. Add it as a repository secret named GIST_SECRET
+      - uses: schneegans/dynamic-badges-action@v1.7.0
+        if: >-
+          github.event.workflow_run.head_branch == 'main' &&
+          steps.test-reporter.outcome == 'success'
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: YOUR_GIST_ID
+          filename: mutiny-tests.json
+          label: tests
+          message: >-
+            ${{ steps.test-reporter.outputs.passed }} passed,
+            ${{ steps.test-reporter.outputs.skipped }} skipped
+          color: ${{ steps.test-reporter.outputs.failed != '0' && 'red' || 'brightgreen' }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="docs/_static/logo.png" alt="Mu::tiny" width="300">
 
 [![Basic builds](https://github.com/thetic/mutiny/actions/workflows/basic.yml/badge.svg)](https://github.com/thetic/mutiny/actions/workflows/basic.yml)
-[![JUnit Tests](https://github.com/thetic/mutiny/actions/workflows/test-report.yml/badge.svg)](https://github.com/thetic/mutiny/actions/workflows/test-report.yml)
+[![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/thetic/YOUR_GIST_ID/raw/mutiny-tests.json)](https://github.com/thetic/mutiny/actions/workflows/test-report.yml)
 [![Coverage Status](https://coveralls.io/repos/github/thetic/mutiny/badge.svg)](https://coveralls.io/github/thetic/mutiny)
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="docs/_static/logo.png" alt="Mu::tiny" width="300">
 
 [![Basic builds](https://github.com/thetic/mutiny/actions/workflows/basic.yml/badge.svg)](https://github.com/thetic/mutiny/actions/workflows/basic.yml)
+[![JUnit Tests](https://github.com/thetic/mutiny/actions/workflows/test-report.yml/badge.svg)](https://github.com/thetic/mutiny/actions/workflows/test-report.yml)
 [![Coverage Status](https://coveralls.io/repos/github/thetic/mutiny/badge.svg)](https://coveralls.io/github/thetic/mutiny)
 
 ---


### PR DESCRIPTION
## Description
Wires up `schneegans/dynamic-badges-action` in `test-report.yml` to write a shields.io endpoint JSON to a Gist after each successful `main` run, using the `passed`/`skipped` counts from `dorny/test-reporter` outputs. The README badge reads from that Gist URL so it always reflects the latest results on `main` (e.g. "57 passed, 0 skipped").

## Related Issues
Fixes #29

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## One-Time Setup (required before merging)

Before merging, complete these steps and push a follow-up commit replacing `YOUR_GIST_ID` in both `test-report.yml` and `README.md`:

1. **Create the Gist** — go to https://gist.github.com, create a new public gist with filename `mutiny-tests.json` and any content (e.g. `{}`). Copy the ID from the URL (`https://gist.github.com/thetic/<ID>`).
2. **Create a PAT** — https://github.com/settings/tokens → "Generate new token (classic)" → check only the `gist` scope.
3. **Add repo secret** — repo Settings → Secrets and variables → Actions → New repository secret named `GIST_SECRET` with the PAT value.
4. **Replace `YOUR_GIST_ID`** in `.github/workflows/test-report.yml` and `README.md` with the real Gist ID.

After the first `main` push post-merge, CI will populate the Gist and the badge will render.

## Checklist
- [x] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MUTINY_` guards, `mutiny_` C-prefix).
- [x] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.