### PR TITLE
Delete CHECK_EQUAL_ZERO

### DIFF
--- a/docs/assertions.rst
+++ b/docs/assertions.rst
@@ -25,8 +25,8 @@ Boolean
    CHECK(list.empty());
    CHECK(!error_occurred);
 
-Equality (generic)
-------------------
+Equality
+--------
 
 ``CHECK_EQUAL(expected, actual)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -53,10 +53,18 @@ To make :c:macro:`CHECK_EQUAL` work with your own types, provide:
        String string_from(const Colour& c) { return c.name(); }
    } }
 
-``CHECK_EQUAL_ZERO(actual)``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``CHECK_APPROX(expected, actual, threshold)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:c:macro:`CHECK_EQUAL_ZERO` is shorthand for ``CHECK_EQUAL(0, actual)``.
+:c:macro:`CHECK_APPROX` checks that ``expected`` and ``actual`` differ by at
+most ``threshold``. All three operands must share the same numeric type
+(floating-point or integral).
+
+.. code-block:: cpp
+
+   CHECK_APPROX(3.14, compute_pi(), 0.001);
+   CHECK_APPROX(1.0f, compute_float(), 0.01f);
+   CHECK_APPROX(1000, compute_int(), 10);
 
 Relational
 ----------
@@ -71,22 +79,6 @@ literal operator like ``<``, ``>=``, ``!=``.
 
    CHECK_COMPARE(result, >=, 0);
    CHECK_COMPARE(count, !=, 0);
-
-Approximate equality
---------------------
-
-``CHECK_APPROX(expected, actual, threshold)``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:c:macro:`CHECK_APPROX` checks that ``expected`` and ``actual`` differ by at
-most ``threshold``. All three operands must share the same numeric type
-(floating-point or integral).
-
-.. code-block:: cpp
-
-   CHECK_APPROX(3.14, compute_pi(), 0.001);
-   CHECK_APPROX(1.0f, compute_float(), 0.01f);
-   CHECK_APPROX(1000, compute_int(), 10);
 
 String
 ------

--- a/include/mutiny/test/Shell.hpp
+++ b/include/mutiny/test/Shell.hpp
@@ -631,14 +631,6 @@ void check_approx(
 #define CHECK_EQUAL_LOCATION(expected, actual, text, file, line)               \
   mu::tiny::test::check_equal((expected), (actual), text, file, line)
 
-/** @brief Fail if @p actual != 0. Equivalent to CHECK_EQUAL(0, actual). */
-#define CHECK_EQUAL_ZERO(actual) CHECK_EQUAL(0, (actual))
-
-/** @brief CHECK_EQUAL_ZERO with a custom failure message. @see CHECK_EQUAL_ZERO
- */
-#define CHECK_EQUAL_ZERO_TEXT(actual, text)                                    \
-  CHECK_EQUAL_TEXT(0, (actual), (text))
-
 /**
  * @brief Fail if @p first relop @p second is false.
  *

--- a/tests/integration/TestShellMacros.test.cpp
+++ b/tests/integration/TestShellMacros.test.cpp
@@ -69,18 +69,6 @@ void failing_test_method_with_check_equal_text()
   mu::tiny::test::TestingFixture::line_executed_after_check();
 }
 
-void failing_test_method_with_check_equal_zero()
-{
-  CHECK_EQUAL_ZERO(1);
-  mu::tiny::test::TestingFixture::line_executed_after_check();
-}
-
-void failing_test_method_with_check_equal_zero_text()
-{
-  CHECK_EQUAL_ZERO_TEXT(1, "Failed because it failed");
-  mu::tiny::test::TestingFixture::line_executed_after_check();
-}
-
 void failing_test_method_with_bytes_equal()
 {
   CHECK_EQUAL('a', 'b');
@@ -212,8 +200,6 @@ int function_that_returns_a_value()
   CHECK_EQUAL_TEXT(0xab, 0xab, "Shouldn't fail");
   CHECK_EQUAL(100, 100);
   CHECK_EQUAL_TEXT(100, 100, "Shouldn't fail");
-  CHECK_EQUAL_ZERO(0);
-  CHECK_EQUAL_ZERO_TEXT(0, "Shouldn't fail");
   STRCMP_EQUAL("THIS", "THIS");
   STRCMP_EQUAL_TEXT("THIS", "THIS", "Shouldn't fail");
   CHECK_COMPARE(1, <, 2);
@@ -414,35 +400,6 @@ TEST(TestShellMacros, FailureWithCHECK_EQUAL_TEXT)
   fixture.run_test_with_method(failing_test_method_with_check_equal_text);
   CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
   CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <2>");
-  CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
-}
-
-TEST(TestShellMacros, FailureWithCHECK_EQUAL_ZERO)
-{
-  fixture.run_test_with_method(failing_test_method_with_check_equal_zero);
-  CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0>");
-  CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <1>");
-}
-
-TEST(TestShellMacros, passingCheckEqualWillNotBeEvaluatedMultipleTimesWithCHECK_EQUAL_ZERO)
-{
-  count_in_counting_method = 0;
-  CHECK_EQUAL_ZERO(counting_method());
-
-  CHECK_EQUAL(1, count_in_counting_method);
-}
-
-TEST(TestShellMacros, failing_CHECK_EQUAL_ZERO_withParamatersThatDontChangeWillNotGiveAnyWarning)
-{
-  fixture.run_test_with_method(failing_test_method_with_check_equal_zero);
-  fixture.assert_print_contains_not("WARNING");
-}
-
-TEST(TestShellMacros, FailureWithCHECK_EQUAL_ZERO_TEXT)
-{
-  fixture.run_test_with_method(failing_test_method_with_check_equal_zero_text);
-  CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0>");
-  CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <1>");
   CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
 }
 


### PR DESCRIPTION
## Description
Briefly describe the purpose of this change and the problem it solves.

## Related Issues
Fixes # (issue number)

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Manual Verification (Optional)
If you have verified this change on hardware or a simulator not covered by CI (e.g., a specific ARM target), please describe it here:
- **Target:**
- **Result:**

## Checklist
- [x] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MUTINY_` guards, `mutiny_` C-prefix).
- [x] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.
