### PR TITLE
Handle semver rule #4 in ABI check (major version zero)

### DIFF
--- a/.github/scripts/abi_check.sh
+++ b/.github/scripts/abi_check.sh
@@ -10,10 +10,14 @@
 #   4  = ABI change (compatible, e.g. added symbols)
 #   8  = ABI incompatible change (e.g. removed/changed symbols)
 #
-# Semver rules applied:
+# Semver rules applied (stable: major >= 1):
 #   patch bump : no ABI changes allowed
 #   minor bump : compatible additions allowed, incompatible changes not allowed
 #   major bump : all ABI changes allowed (breaking changes are expected)
+#
+# Semver rule #4 (unstable: major == 0):
+#   patch bump : compatible additions allowed, incompatible changes not allowed
+#   minor bump : all ABI changes allowed (breaking changes are expected)
 
 set -e
 
@@ -48,6 +52,14 @@ if [ "$HAS_CHANGE" -eq 0 ] && [ "$HAS_INCOMPATIBLE" -eq 0 ]; then
 fi
 
 if [ "$HAS_INCOMPATIBLE" -ne 0 ]; then
+    if [ "$BASELINE_MAJOR" -eq 0 ] && [ "$CURRENT_MAJOR" -eq 0 ]; then
+        if [ "$CURRENT_MINOR" -gt "$BASELINE_MINOR" ]; then
+            echo "Minor version bump ($BASELINE_VERSION -> $CURRENT_VERSION): incompatible ABI changes are allowed under major version zero."
+            exit 0
+        fi
+        echo "Incompatible ABI change detected without a minor version bump (major version zero)."
+        exit 1
+    fi
     if [ "$CURRENT_MAJOR" -gt "$BASELINE_MAJOR" ]; then
         echo "Major version bump ($BASELINE_VERSION -> $CURRENT_VERSION): incompatible ABI changes are allowed."
         exit 0
@@ -56,6 +68,10 @@ if [ "$HAS_INCOMPATIBLE" -ne 0 ]; then
     exit 1
 fi
 
+if [ "$BASELINE_MAJOR" -eq 0 ] && [ "$CURRENT_MAJOR" -eq 0 ]; then
+    echo "Patch or minor version bump ($BASELINE_VERSION -> $CURRENT_VERSION): compatible ABI changes are allowed under major version zero."
+    exit 0
+fi
 if [ "$CURRENT_MAJOR" -gt "$BASELINE_MAJOR" ]; then
     echo "Major version bump ($BASELINE_VERSION -> $CURRENT_VERSION): compatible ABI changes are allowed."
     exit 0


### PR DESCRIPTION
## Description

Under [semver rule #4](https://semver.org/#spec-item-4), major version zero (`0.y.z`) is for initial development — anything may change at any time. `abi_check.sh` previously applied stable-version rules unconditionally, so a `0.y.z` patch bump would fail on any ABI change and breaking changes could never be allowed at all (no major bump is coming any time soon).

This change adds a separate rule path for `major == 0`:
- **patch bump** (`0.y.z` → `0.y.z+1`): compatible ABI additions are allowed
- **minor bump** (`0.y.z` → `0.y+1.0`): all ABI changes (including incompatible) are allowed
- Stable-version rules (`major >= 1`) are unchanged.

## Related Issues

Fixes # (issue number)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Manual Verification (Optional)

Not applicable (script logic change, verified by reading the decision table).

## Checklist
- [x] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MUTINY_` guards, `mutiny_` C-prefix).
- [x] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.