### PR TITLE
Use latest release tag as ABI check baseline

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -30,10 +30,18 @@ jobs:
       - name: Install Libabigail
         run: sudo apt-get update && sudo apt-get install -y abigail-tools
 
+      - name: Get Latest Release Tag
+        id: latest_release
+        run: |
+          tag=$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Checkout Base Branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ steps.latest_release.outputs.tag }}
           path: baseline
 
       - name: Configure Baseline Build


### PR DESCRIPTION
## Description

The `abi_check` job was using `${{ github.base_ref }}` (HEAD of the target branch) as the baseline for `abidiff`. This means the check compared against unreleased in-flight changes rather than what users have actually shipped. Switching to the latest GitHub release tag gives the check meaningful semantics: "does this PR break the ABI of the last published release?"

## Related Issues

Fixes # (issue number)

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Manual Verification (Optional)

N/A — CI-only change.

## Checklist
- [ ] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MUTINY_` guards, `mutiny_` C-prefix).
- [ ] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.