### PR TITLE
Fix stale thetic/mutiny references following repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ project(my_tests)
 
 include(FetchContent)
 FetchContent_Declare(
-    mutiny
+    mu.tiny
     GIT_REPOSITORY    https://github.com/thetic/mu.tiny.git
     GIT_TAG           v0.1.0
     FIND_PACKAGE_ARGS 0.1
 )
-FetchContent_MakeAvailable(mutiny)
+FetchContent_MakeAvailable(mu.tiny)
 
 add_executable(my_tests main.cpp widget.test.cpp)
 target_link_libraries(my_tests PRIVATE mu::tiny)
 
 include(CTest)
-include(mutiny)
+include(mu.tiny)
 mutiny_discover_tests(my_tests)
 ```
 
@@ -43,7 +43,7 @@ If _mu::tiny_ is already installed and you prefer not to use
 [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html) directly:
 
 ```cmake
-find_package(mutiny 0.1 REQUIRED)
+find_package(mu.tiny 0.1 REQUIRED)
 ```
 
 ## Headers

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="docs/_static/logo.png" alt="mu::tiny" width="300">
 
-[![Basic builds](https://github.com/thetic/mutiny/actions/workflows/basic.yml/badge.svg)](https://github.com/thetic/mutiny/actions/workflows/basic.yml)
-[![Coverage Status](https://coveralls.io/repos/github/thetic/mutiny/badge.svg)](https://coveralls.io/github/thetic/mutiny)
+[![Basic builds](https://github.com/thetic/mu.tiny/actions/workflows/basic.yml/badge.svg)](https://github.com/thetic/mu.tiny/actions/workflows/basic.yml)
+[![Coverage Status](https://coveralls.io/repos/github/thetic/mu.tiny/badge.svg)](https://coveralls.io/github/thetic/mu.tiny)
 
 ---
 
@@ -24,7 +24,7 @@ project(my_tests)
 include(FetchContent)
 FetchContent_Declare(
     mutiny
-    GIT_REPOSITORY    https://github.com/thetic/mutiny.git
+    GIT_REPOSITORY    https://github.com/thetic/mu.tiny.git
     GIT_TAG           v0.1.0
     FIND_PACKAGE_ARGS 0.1
 )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 # -- Project information -------------------------------------------------------
 
-project = "mutiny"
+project = "mu::tiny"
 copyright = "2026, Chad Condon"
 author = "Chad Condon"
 language = "en"
@@ -35,8 +35,8 @@ intersphinx_mapping = {
 # -- Breathe -------------------------------------------------------------------
 
 # Exhale writes XML here (relative to confdir); must match exhale_args below.
-breathe_projects = {"mutiny": "./doxyoutput/xml"}
-breathe_default_project = "mutiny"
+breathe_projects = {"mu::tiny": "./doxyoutput/xml"}
+breathe_default_project = "mu::tiny"
 breathe_domain_by_extension = {"hpp": "cpp"}
 
 # -- Exhale --------------------------------------------------------------------
@@ -81,7 +81,7 @@ exhale_args = {
 
 # -- GitHub source links -------------------------------------------------------
 
-_github_root = "https://github.com/thetic/mutiny"
+_github_root = "https://github.com/thetic/mu.tiny"
 _github_branch = os.environ.get("DOCS_GITHUB_REF", "main")
 
 # :source:`filename <path/to/file>` → link into the GitHub tree
@@ -94,7 +94,7 @@ extlinks = {
 html_theme = "furo"
 html_static_path = ["_static"]
 templates_path = ["_templates"]
-html_title = "mutiny"
+html_title = "mu::tiny"
 html_logo = "_static/logo.png"
 html_theme_options = {
     "source_repository": _github_root,

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -28,7 +28,7 @@ is not installed, CMake fetches and builds it from source automatically:
    include(FetchContent)
    FetchContent_Declare(
        mutiny
-       GIT_REPOSITORY https://github.com/thetic/mutiny.git
+       GIT_REPOSITORY https://github.com/thetic/mu.tiny.git
        GIT_TAG        v0.1.0
        FIND_PACKAGE_ARGS 0.1
    )

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -27,18 +27,18 @@ is not installed, CMake fetches and builds it from source automatically:
 
    include(FetchContent)
    FetchContent_Declare(
-       mutiny
+       mu.tiny
        GIT_REPOSITORY https://github.com/thetic/mu.tiny.git
        GIT_TAG        v0.1.0
        FIND_PACKAGE_ARGS 0.1
    )
-   FetchContent_MakeAvailable(mutiny)
+   FetchContent_MakeAvailable(mu.tiny)
 
    add_executable(my_tests main.cpp widget.test.cpp)
    target_link_libraries(my_tests PRIVATE mu::tiny)
 
    include(CTest)
-   include(Mutiny)
+   include(mu.tiny)
    mutiny_discover_tests(my_tests)
 
 If *mu::tiny* is already installed and you prefer not to use
@@ -47,27 +47,27 @@ If *mu::tiny* is already installed and you prefer not to use
 
 .. code-block:: cmake
 
-   find_package(mutiny 0.1 REQUIRED)
+   find_package(mu.tiny 0.1 REQUIRED)
 
 Headers
 ~~~~~~~
 
-All public headers live under ``include/mutiny/``. The main headers you'll use:
+All public headers live under ``include/mu/tiny/``. The main headers you'll use:
 
 .. list-table::
    :header-rows: 1
 
    * - Header
      - Purpose
-   * - ``mutiny/test.hpp``
+   * - ``mu/tiny/test.hpp``
      - Test and assertion macros (:c:macro:`TEST_GROUP`, :c:macro:`TEST`, :c:macro:`CHECK`, etc.)
-   * - ``mutiny/mock.hpp``
+   * - ``mu/tiny/mock.hpp``
      - Mock framework (:cpp:func:`mock <mu::tiny::mock::mock>`, :cpp:class:`Support <mu::tiny::mock::Support>`)
-   * - ``mutiny/test.h``
+   * - ``mu/tiny/test.h``
      - C interface (include in ``.test.c`` files)
-   * - ``mutiny/test/CommandLineRunner.hpp``
+   * - ``mu/tiny/test/CommandLineRunner.hpp``
      - :cpp:class:`CommandLineRunner <mu::tiny::test::CommandLineRunner>` (``main()`` runner)
-   * - ``mutiny/test/Ordered.hpp``
+   * - ``mu/tiny/test/Ordered.hpp``
      - :c:macro:`TEST_ORDERED` macro
 
 Writing ``main()``
@@ -78,7 +78,7 @@ Every test executable needs a ``main()``. The simplest form uses
 
 .. code-block:: cpp
 
-   #include "mutiny/test/CommandLineRunner.hpp"
+   #include "mu/tiny/test/CommandLineRunner.hpp"
 
    int main(int argc, char** argv)
    {
@@ -93,10 +93,10 @@ To add plugins (e.g.
 
 .. code-block:: cpp
 
-   #include "mutiny/test/CommandLineRunner.hpp"
-   #include "mutiny/test/JUnitOutputPlugin.hpp"
-   #include "mutiny/mock/SupportPlugin.hpp"
-   #include "mutiny/test/Registry.hpp"
+   #include "mu/tiny/test/CommandLineRunner.hpp"
+   #include "mu/tiny/test/JUnitOutputPlugin.hpp"
+   #include "mu/tiny/mock/SupportPlugin.hpp"
+   #include "mu/tiny/test/Registry.hpp"
 
    int main(int argc, char** argv)
    {

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,7 @@ if(PROJECT_IS_TOP_LEVEL)
     include(FetchContent)
     FetchContent_Declare(
         mu.tiny
-        GIT_REPOSITORY https://github.com/thetic/mutiny.git
+        GIT_REPOSITORY https://github.com/thetic/mu.tiny.git
         GIT_TAG v0.1.0
         FIND_PACKAGE_ARGS 0.1
     )


### PR DESCRIPTION
## Description

Following the repository rename from `thetic/mutiny` to `thetic/mu.tiny`, update all hardcoded references in docs, examples, and configuration:

- **Badge URLs** in `README.md`
- **CMake snippets** (`FetchContent_Declare`, `FetchContent_MakeAvailable`, `include()`, `find_package()`) in `README.md`, `docs/getting-started.rst`, and `examples/CMakeLists.txt`
- **Include paths** in `docs/getting-started.rst` (`mutiny/` → `mu/tiny/`)
- **Sphinx metadata** in `docs/conf.py` (`project`, `breathe_projects`, `html_title`, `_github_root`)
- Incidentally fixes a pre-existing case bug: `include(Mutiny)` → `include(mu.tiny)` in `docs/getting-started.rst`

## Related Issues

N/A

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Manual Verification (Optional)

N/A

## Checklist

- [x] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MUTINY_` guards, `mutiny_` C-prefix).
- [ ] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.