### PR TITLE
Enable WARN_IF_UNDOCUMENTED in Doxygen config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ exhale_args = {
         MACRO_EXPANSION      = YES
         INCLUDE_PATH         = ../include
         PREDEFINED           += MUTINY_EXPORT=
-        WARN_IF_UNDOCUMENTED = NO
+        WARN_IF_UNDOCUMENTED = YES
         WARN_AS_ERROR        = YES
         QUIET                = YES
         # Omit <programlisting> from XML so Exhale skips generating


### PR DESCRIPTION
## Description

Set `WARN_IF_UNDOCUMENTED = YES` in the Doxygen configuration inside `docs/conf.py`. Since `WARN_AS_ERROR = YES` is already set, this now turns any missing Doxygen comment on a public symbol into a hard build failure — preventing silent documentation gaps from being introduced going forward.

All existing public symbols are already documented, so the docs build passes without changes to any headers.

## Related Issues
Fixes #66

## Type of Change
- [x] Documentation update

## Checklist
- [x] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [x] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.