### PR TITLE
Add pkg-config support

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -250,6 +250,15 @@ jobs:
           ctest --test-dir examples_build
         if: ${{ matrix.install }}
 
+      - name: Validate pkg-config
+        run: |
+          pkg-config --exists mu.tiny
+          pkg-config --cflags mu.tiny
+          pkg-config --libs mu.tiny
+          printf '#include <mu/tiny/test.hpp>\nint main(){}\n' > /tmp/pctest.cpp
+          c++ $(pkg-config --cflags --libs mu.tiny) /tmp/pctest.cpp -o /tmp/pctest
+        if: ${{ matrix.install && !startswith(matrix.os, 'windows') && !startswith(matrix.os, 'macos') }}
+
       - name: Use FetchContent (source build)
         run: |
           cmake -B examples_fc_build -S examples \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,13 @@ if(PROJECT_IS_TOP_LEVEL)
             COMPONENT mutiny_Development
     )
 
+    configure_file(cfg/mu.tiny.pc.in ${CMAKE_CURRENT_BINARY_DIR}/mu.tiny.pc @ONLY)
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/mu.tiny.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+        COMPONENT mutiny_Development
+    )
+
     include(CMakePackageConfigHelpers)
 
     set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/cfg/mu.tiny.pc.in
+++ b/cfg/mu.tiny.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: mu.tiny
+Description: mu::tiny C++ unit testing and mocking framework
+URL: https://github.com/thetic/mu.tiny
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lmutiny
+Cflags: -I${includedir}


### PR DESCRIPTION
## Description

Adds `pkg-config` discovery support so projects using Meson, Make, or other non-CMake build systems can find *Mu::tiny* without manual flag configuration.

## Related Issues

Fixes #67

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes

- **`cfg/mu.tiny.pc.in`** — new template; `configure_file(@ONLY)` substitutes `@CMAKE_INSTALL_PREFIX@`, `@CMAKE_INSTALL_FULL_LIBDIR@`, `@CMAKE_INSTALL_FULL_INCLUDEDIR@`, and `@PROJECT_VERSION@` at configure time.
- **`CMakeLists.txt`** — generates `mu.tiny.pc` in the binary dir and installs it to `${CMAKE_INSTALL_LIBDIR}/pkgconfig` as part of the `mutiny_Development` component (inside the existing `PROJECT_IS_TOP_LEVEL` block, after `include(GNUInstallDirs)`).
- **`.github/workflows/basic.yml`** — adds a *Validate pkg-config* step (Linux install builds only) that:
  1. Checks `pkg-config --exists mu.tiny`
  2. Checks `--cflags` / `--libs` output
  3. Compiles a minimal `#include <mu/tiny/test.hpp>` program using the pkg-config flags

## Manual Verification (Optional)

Verified locally:
- **Target:** Linux x86_64, CMake GNU preset
- **Result:** `build/GNU/mu.tiny.pc` generated with correct prefix (`/usr/local`), libdir, includedir, and version `0.5.0`

## Checklist

- [ ] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [x] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.