### PR TITLE
docs: add changelog page via sphinx-github-changelog

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,6 +64,7 @@ jobs:
         run: uv run --project docs make -C docs html
         env:
           DOCS_GITHUB_REF: ${{ steps.ref.outputs.github_ref }}
+          SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.SPHINX_GITHUB_CHANGELOG_TOKEN }}
 
       - name: Prepare gh-pages worktree
         run: |

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,5 @@
+Changelog
+=========
+
+.. changelog::
+   :github: https://github.com/thetic/mu.tiny/releases

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.linkcode",
+    "sphinx_github_changelog",
     "sphinxcontrib.moderncmakedomain",
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,8 @@ extensions = [
     "sphinxcontrib.moderncmakedomain",
 ]
 
+sphinx_github_changelog_token = os.environ.get("SPHINX_GITHUB_CHANGELOG_TOKEN")
+
 intersphinx_mapping = {
     "cmake": ("https://cmake.org/cmake/help/latest/", None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,3 +33,9 @@ and low-resource targets.
    :caption: Contributing
 
    contributing
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Release History
+
+   changelog

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "sphinxcontrib-moderncmakedomain>=3.0",
     "myst-parser>=2.0",
     "furo",
+    "sphinx-github-changelog>=1.2",
 ]
 
 [tool.uv]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -304,6 +304,7 @@ dependencies = [
     { name = "furo" },
     { name = "myst-parser" },
     { name = "sphinx" },
+    { name = "sphinx-github-changelog" },
     { name = "sphinxcontrib-moderncmakedomain" },
 ]
 
@@ -314,6 +315,7 @@ requires-dist = [
     { name = "furo" },
     { name = "myst-parser", specifier = ">=2.0" },
     { name = "sphinx", specifier = ">=7.0,<10" },
+    { name = "sphinx-github-changelog", specifier = ">=1.2" },
     { name = "sphinxcontrib-moderncmakedomain", specifier = ">=3.0" },
 ]
 
@@ -467,6 +469,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
+]
+
+[[package]]
+name = "sphinx-github-changelog"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "requests" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/8a/e3b943c59927280c9c5bfb94064845a57f36bc2e021435adbfb7d3ecca1f/sphinx_github_changelog-1.7.2.tar.gz", hash = "sha256:79f11f30ec5b1ae52a1742a6dc702644203b164732a1af4b049ebe522ff484e4", size = 78662, upload-time = "2026-03-23T21:49:45.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/6c/d8db14cbf2171cae049660eacddf858a35818343e618b442993a8b0a8885/sphinx_github_changelog-1.7.2-py3-none-any.whl", hash = "sha256:fef384fb9b60bfb8f1c4cc5941dab674b0e52456cd3fe05ef2c763833054d680", size = 11416, upload-time = "2026-03-23T21:49:43.74Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds a Changelog page to the Sphinx documentation site that renders GitHub Releases using the [`sphinx-github-changelog`](https://github.com/ewjoachim/sphinx-github-changelog) extension. Previously, users browsing the docs had no way to see version history without leaving the site.

## Related Issues

Fixes #69

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [x] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.