### PR TITLE
Add docs badge to README and uv link to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ When testing framework internals (behaviors that are supposed to fail), use `Tes
 
 ## Documentation
 
-User-facing features must be documented in `docs/`. The docs are written in reStructuredText (`.rst`) and built with Sphinx. Run `uv run --project docs sphinx-build docs docs/_build` to preview locally.
+User-facing features must be documented in `docs/`. The docs are written in reStructuredText (`.rst`) and built with Sphinx. Run `uv run --project docs sphinx-build docs docs/_build` to preview locally ([uv](https://docs.astral.sh/uv/) is a fast Python package manager; install it first if needed).
 
 ## Submitting Changes
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Basic builds](https://github.com/thetic/mu.tiny/actions/workflows/basic.yml/badge.svg)](https://github.com/thetic/mu.tiny/actions/workflows/basic.yml)
 [![Coverage Status](https://coveralls.io/repos/github/thetic/mu.tiny/badge.svg)](https://coveralls.io/github/thetic/mu.tiny)
+[![Documentation](https://img.shields.io/badge/docs-online-blue)](https://thetic.github.io/mu.tiny/)
 
 ---
 


### PR DESCRIPTION
## Description

Two small documentation improvements to improve discoverability for users and contributors.

## Related Issues

Fixes #65
Fixes #68

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [x] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.