### PR TITLE
Add UBSan preset and CI job

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -163,6 +163,9 @@ jobs:
           - name: Address Sanitizer
             os: ubuntu-latest
             preset: asan
+          - name: Undefined Behavior Sanitizer
+            os: ubuntu-latest
+            preset: ubsan
           - name: Linux Shared Library
             os: ubuntu-latest
             preset: shared

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -152,6 +152,19 @@
       }
     },
     {
+      "name": "ubsan",
+      "inherits": ["Clang"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "MUTINY_USE_STD_STRING": false
+      },
+      "environment": {
+        "CFLAGS": "-fsanitize=undefined -fno-omit-frame-pointer",
+        "CXXFLAGS": "-fsanitize=undefined -fno-omit-frame-pointer",
+        "LDFLAGS": "-fsanitize=undefined"
+      }
+    },
+    {
       "name": "detailed",
       "inherits": ["defaults"],
       "cacheVariables": {
@@ -181,6 +194,7 @@
     { "name": "no-exceptions", "inherits": "base", "configurePreset": "no-exceptions" },
     { "name": "asan",          "inherits": "base", "configurePreset": "asan" },
     { "name": "msan",          "inherits": "base", "configurePreset": "msan" },
+    { "name": "ubsan",         "inherits": "base", "configurePreset": "ubsan" },
     { "name": "detailed",      "inherits": "base", "configurePreset": "detailed" }
   ],
   "testPresets": [
@@ -209,6 +223,7 @@
     { "name": "no-exceptions", "inherits": "base", "configurePreset": "no-exceptions" },
     { "name": "asan",          "inherits": "base", "configurePreset": "asan" },
     { "name": "msan",          "inherits": "base", "configurePreset": "msan" },
+    { "name": "ubsan",         "inherits": "base", "configurePreset": "ubsan" },
     { "name": "detailed",      "inherits": "base", "configurePreset": "detailed" }
   ],
   "packagePresets": [
@@ -337,6 +352,14 @@
         { "type": "configure", "name": "msan" },
         { "type": "build",     "name": "msan" },
         { "type": "test",      "name": "msan" }
+      ]
+    },
+    {
+      "name": "ubsan",
+      "steps": [
+        { "type": "configure", "name": "ubsan" },
+        { "type": "build",     "name": "ubsan" },
+        { "type": "test",      "name": "ubsan" }
       ]
     },
     {


### PR DESCRIPTION
## Description

Adds Undefined Behavior Sanitizer (UBSan) coverage by introducing a `ubsan` preset and corresponding CI matrix entry.

The `ubsan` configure preset inherits from `Clang`, sets `Debug` build type, and passes `-fsanitize=undefined -fno-omit-frame-pointer` via `CFLAGS`/`CXXFLAGS`, with `-fsanitize=undefined` in `LDFLAGS`. Build, test, and workflow presets follow the same pattern as the existing `asan` preset.

All 52 tests pass locally under UBSan with no violations.

## Related Issues

Fixes #64

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [x] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.