### PR TITLE
Add PR comment to test report workflow

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -24,3 +24,4 @@ jobs:
           path: "**/mutiny_*.xml"
           reporter: java-junit
           use-actions-summary: false
+          comment-title: 'Test Results'


### PR DESCRIPTION
## Description

Adds `comment-title` to the `dorny/test-reporter` step so that JUnit XML results are posted as a comment on the pull request page, rather than only appearing in the hidden check run UI.

## Related Issues

Fixes #29

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [x] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.