### PR TITLE
Switch to mikepenz/action-junit-report for PR comments

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -24,4 +24,3 @@ jobs:
           path: "**/mutiny_*.xml"
           reporter: java-junit
           use-actions-summary: false
-          comment-title: 'Test Results'

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,7 +1,7 @@
 ---
 name: 'Test Report'
-# This workflow must live in a separate file and be triggered by 'workflow_run' 
-# to allow it to have 'write' permissions (for creating checks and PR comments) 
+# This workflow must live in a separate file and be triggered by 'workflow_run'
+# to allow it to have 'write' permissions (for creating checks and PR comments)
 # even when the triggering workflow ('Basic builds') is run from a fork.
 "on":
   workflow_run:
@@ -17,10 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: dorny/test-reporter@v3
+      - uses: actions/download-artifact@v4
         with:
-          artifact: test-results
-          name: JUnit Tests
-          path: "**/mutiny_*.xml"
-          reporter: java-junit
-          use-actions-summary: false
+          name: test-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: "**/mutiny_*.xml"
+          check_name: 'JUnit Tests'
+          comment: true
+          pr_id: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
## Description

Replaces `dorny/test-reporter` with `mikepenz/action-junit-report`, which supports posting a comment on the PR page with a test results summary. Uses an explicit `actions/download-artifact` step to fetch the JUnit XML from the triggering workflow run, and passes `pr_id` from the `workflow_run` context so the comment lands on the correct PR.

## Related Issues

Fixes #29

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have written/updated documentation in `docs/` for any user-facing changes.
- [ ] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [ ] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [ ] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.