### PR TITLE
Bump test-report actions to node24 versions

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -291,11 +291,16 @@ jobs:
       - run: cmake --preset=defaults -DMUTINY_JUNIT_REPORT=TRUE
       - run: cmake --build --preset defaults
       - run: ctest --preset defaults
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo ${{ github.event.pull_request.number }} > pr_number.txt
       - uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: test-results
-          path: "build/defaults/**/mutiny_*.xml"
+          path: |
+            build/defaults/**/mutiny_*.xml
+            pr_number.txt
 
   tap_validate:
     name: TAP Output Validation

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -22,9 +22,12 @@ jobs:
           name: test-results
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr_number.txt 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
       - uses: mikepenz/action-junit-report@v6
         with:
           report_paths: "**/mutiny_*.xml"
           check_name: 'JUnit Tests'
           comment: true
-          pr_id: ${{ github.event.workflow_run.pull_requests[0].number }}
+          pr_id: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: test-results
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: mikepenz/action-junit-report@v4
+      - uses: mikepenz/action-junit-report@v6
         with:
           report_paths: "**/mutiny_*.xml"
           check_name: 'JUnit Tests'


### PR DESCRIPTION
## Description

Fixes JUnit test results not appearing as PR comments (thetic/mu.tiny#29).

**Root causes addressed:**

1. `dorny/test-reporter` (removed in #81) had no comment support; replaced with `mikepenz/action-junit-report`.
2. `@v4` of that action predated the `comment`/`pr_id` inputs — bumped to `@v6`.
3. `actions/download-artifact@v4` was on node20 — bumped to `@v8`.
4. `github.event.workflow_run.pull_requests` is empty for fork PRs, so `pr_id` would never be set. The PR number is now saved as a file in the `basic.yml` artifact and read back in `test-report.yml`.

## Related Issues

Fixes #29

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have written/updated documentation in `docs/` for any user-facing changes.
- [ ] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [ ] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [ ] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.