### PR TITLE
replace private static member functions with internal free functions

### DIFF
--- a/include/mu/tiny/String.hpp
+++ b/include/mu/tiny/String.hpp
@@ -186,8 +186,6 @@ private:
   char* buffer_;
   size_t buffer_size_;
   size_t size_;
-
-  static char* get_empty_string();
 };
 #endif
 

--- a/include/mu/tiny/test/CommandLineArguments.hpp
+++ b/include/mu/tiny/test/CommandLineArguments.hpp
@@ -116,12 +116,6 @@ private:
   size_t shuffle_seed_{ 0 };
   Filter* group_filters_{ nullptr };
   Filter* name_filters_{ nullptr };
-  static String get_parameter_field(
-      int argc,
-      const char* const* argv,
-      int& i,
-      const String& parameter_name
-  );
   void set_repeat_count(int argc, const char* const* argv, int& index);
   bool set_shuffle(int argc, const char* const* argv, int& index);
   void add_group_filter(int argc, const char* const* argv, int& index);

--- a/include/mu/tiny/test/Ordered.hpp
+++ b/include/mu/tiny/test/Ordered.hpp
@@ -114,12 +114,6 @@ public:
       int level
   ) noexcept;
   virtual ~OrderedInstaller() = default;
-
-private:
-  static void add_ordered_test_in_order(OrderedShell* test);
-  static void add_ordered_test_in_order_not_at_head_position(
-      OrderedShell* test
-  );
 };
 
 } // namespace test

--- a/include/mu/tiny/test/Registry.hpp
+++ b/include/mu/tiny/test/Registry.hpp
@@ -190,7 +190,6 @@ public:
 
 private:
   bool test_should_run(Shell* test, Result& result);
-  static bool end_of_group(Shell* test);
 
   Shell* tests_{ nullptr };
   const Filter* name_filters_{ nullptr };

--- a/include/mu/tiny/test/Shell.hpp
+++ b/include/mu/tiny/test/Shell.hpp
@@ -418,13 +418,6 @@ private:
   Shell* next_;
   bool has_failed_;
 
-  static void set_test_result(Result* result);
-  static void set_current_test(Shell* test);
-  static bool match(const char* target, const Filter* filters);
-
-  static Shell* current_test_;
-  static Result* test_result_;
-
   static const Terminator* current_test_terminator_;
   static const Terminator* current_test_terminator_without_exceptions_;
   static bool rethrow_exceptions_;

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -68,17 +68,17 @@ bool is_upper(char ch)
 {
   return 'A' <= ch && 'Z' >= ch;
 }
-#endif
-} // namespace
 
-#if !MUTINY_USE_STD_STRING
-char* String::get_empty_string()
+char* get_empty_string()
 {
   char* buf = new char[1];
   buf[0] = '\0';
   return buf;
 }
+#endif
+} // namespace
 
+#if !MUTINY_USE_STD_STRING
 void String::deallocate_internal_buffer()
 {
   if (buffer_ != nullptr) {

--- a/src/test/CommandLineArguments.cpp
+++ b/src/test/CommandLineArguments.cpp
@@ -12,6 +12,24 @@ namespace tiny {
 namespace test {
 
 namespace {
+String get_parameter_field(
+    int argc,
+    const char* const* argv,
+    int& i,
+    const String& parameter_name
+)
+{
+  size_t parameter_length = parameter_name.size();
+  String parameter(argv[i]);
+  if (parameter.size() > parameter_length) {
+    return argv[i] + parameter_length;
+  }
+  if (i + 1 < argc) {
+    return argv[++i];
+  }
+  return "";
+}
+
 String sub_string_from_till(
     const String& str,
     char start_char,
@@ -418,24 +436,6 @@ bool CommandLineArguments::set_shuffle(
     }
   }
   return (shuffle_seed_ != 0);
-}
-
-String CommandLineArguments::get_parameter_field(
-    int argc,
-    const char* const* argv,
-    int& i,
-    const String& parameter_name
-)
-{
-  size_t parameter_length = parameter_name.size();
-  String parameter(argv[i]);
-  if (parameter.size() > parameter_length) {
-    return argv[i] + parameter_length;
-  }
-  if (i + 1 < argc) {
-    return argv[++i];
-  }
-  return "";
 }
 
 void CommandLineArguments::add_group_filter(

--- a/src/test/Ordered.cpp
+++ b/src/test/Ordered.cpp
@@ -6,6 +6,35 @@ namespace mu {
 namespace tiny {
 namespace test {
 
+namespace {
+void add_ordered_test_in_order_not_at_head_position(OrderedShell* test);
+
+void add_ordered_test_in_order(OrderedShell* test)
+{
+  if (test->get_level() < OrderedShell::get_ordered_test_head()->get_level()) {
+    OrderedShell::add_ordered_test_to_head(test);
+  } else {
+    add_ordered_test_in_order_not_at_head_position(test);
+  }
+}
+
+void add_ordered_test_in_order_not_at_head_position(OrderedShell* test)
+{
+  OrderedShell* current = OrderedShell::get_ordered_test_head();
+  while (current->get_next_ordered_test() != nullptr) {
+
+    if (current->get_next_ordered_test()->get_level() > test->get_level()) {
+      test->add_ordered_test(current->get_next_ordered_test());
+      current->add_ordered_test(test);
+      return;
+    }
+    current = current->get_next_ordered_test();
+  }
+  test->add_ordered_test(current->get_next_ordered_test());
+  current->add_ordered_test(test);
+}
+} // namespace
+
 OrderedShell* OrderedShell::ordered_tests_head_ = nullptr;
 
 bool OrderedShell::is_ordered() const
@@ -86,33 +115,6 @@ OrderedInstaller::OrderedInstaller(
   } else {
     add_ordered_test_in_order(&test);
   }
-}
-
-void OrderedInstaller::add_ordered_test_in_order(OrderedShell* test)
-{
-  if (test->get_level() < OrderedShell::get_ordered_test_head()->get_level()) {
-    OrderedShell::add_ordered_test_to_head(test);
-  } else {
-    add_ordered_test_in_order_not_at_head_position(test);
-  }
-}
-
-void OrderedInstaller::add_ordered_test_in_order_not_at_head_position(
-    OrderedShell* test
-)
-{
-  OrderedShell* current = OrderedShell::get_ordered_test_head();
-  while (current->get_next_ordered_test() != nullptr) {
-
-    if (current->get_next_ordered_test()->get_level() > test->get_level()) {
-      test->add_ordered_test(current->get_next_ordered_test());
-      current->add_ordered_test(test);
-      return;
-    }
-    current = current->get_next_ordered_test();
-  }
-  test->add_ordered_test(current->get_next_ordered_test());
-  current->add_ordered_test(test);
 }
 
 } // namespace test

--- a/src/test/Registry.cpp
+++ b/src/test/Registry.cpp
@@ -10,6 +10,16 @@ namespace mu {
 namespace tiny {
 namespace test {
 
+namespace {
+bool end_of_group(Shell* test)
+{
+  return (
+      (test == nullptr) || (test->get_next() == nullptr) ||
+      test->get_group() != test->get_next()->get_group()
+  );
+}
+} // namespace
+
 Registry::Registry()
   : first_plugin_(NullPlugin::instance())
 
@@ -167,14 +177,6 @@ void Registry::list_test_group_locations(Result& result)
   }
 
   result.print(group_locations.c_str());
-}
-
-bool Registry::end_of_group(Shell* test)
-{
-  return (
-      (test == nullptr) || (test->get_next() == nullptr) ||
-      test->get_group() != test->get_next()->get_group()
-  );
 }
 
 size_t Registry::count_tests()

--- a/src/test/Shell.cpp
+++ b/src/test/Shell.cpp
@@ -96,6 +96,34 @@ const CrashingTerminatorWithoutExceptions
         CrashingTerminatorWithoutExceptions();
 
 void (*please_crash_me_right_now)() = abort;
+
+Result* test_result = nullptr;
+Shell* current_test = nullptr;
+
+bool match(const char* target, const Filter* filters)
+{
+  if (filters == nullptr) {
+    return true;
+  }
+
+  for (; filters != nullptr; filters = filters->get_next()) {
+    if (filters->match(target)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void set_test_result(Result* result)
+{
+  test_result = result;
+}
+
+void set_current_test(Shell* test)
+{
+  current_test = test;
+}
 } // namespace
 
 bool approx_equal(double d1, double d2, double threshold)
@@ -185,8 +213,8 @@ void Shell::run_one_test_in_current_process(Plugin* plugin, Result& result)
   Shell* saved_test = Shell::get_current();
   Result* saved_result = Shell::get_test_result();
 
-  Shell::set_test_result(&result);
-  Shell::set_current_test(this);
+  set_test_result(&result);
+  set_current_test(this);
 
   Test* test_to_run = nullptr;
 
@@ -201,8 +229,8 @@ void Shell::run_one_test_in_current_process(Plugin* plugin, Result& result)
     test_to_run->run();
     result.print_very_verbose("\n------ after runTest: ");
 
-    Shell::set_current_test(saved_test);
-    Shell::set_test_result(saved_result);
+    set_current_test(saved_test);
+    set_test_result(saved_result);
 #if MUTINY_HAVE_EXCEPTIONS
   } catch (...) {
     destroy_test(test_to_run);
@@ -312,21 +340,6 @@ const char* Shell::get_file() const
 size_t Shell::get_line_number() const
 {
   return line_number_;
-}
-
-bool Shell::match(const char* target, const Filter* filters)
-{
-  if (filters == nullptr) {
-    return true;
-  }
-
-  for (; filters != nullptr; filters = filters->get_next()) {
-    if (filters->match(target)) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 bool Shell::should_run(
@@ -649,33 +662,20 @@ void Shell::print_very_verbose(const char* text)
   get_test_result()->print_very_verbose(text);
 }
 
-Result* Shell::test_result_ = nullptr;
-Shell* Shell::current_test_ = nullptr;
-
-void Shell::set_test_result(Result* result)
-{
-  test_result_ = result;
-}
-
-void Shell::set_current_test(Shell* test)
-{
-  current_test_ = test;
-}
-
 Result* Shell::get_test_result()
 {
-  if (test_result_ == nullptr) {
+  if (test_result == nullptr) {
     return &OutsideTestRunnerUTest::instance().get_result();
   }
-  return test_result_;
+  return test_result;
 }
 
 Shell* Shell::get_current()
 {
-  if (current_test_ == nullptr) {
+  if (current_test == nullptr) {
     return &OutsideTestRunnerUTest::instance();
   }
-  return current_test_;
+  return current_test;
 }
 
 const Terminator& Shell::get_current_test_terminator()


### PR DESCRIPTION
## Description

Private `static` member functions that neither access `this` nor any instance/class state are free functions in disguise — the `static` keyword just artificially couples them to the class. This PR moves them to anonymous namespaces in their respective translation units, making TU-local encapsulation explicit rather than class-private.

Functions moved:
- `Shell::match`, `Shell::set_test_result`, `Shell::set_current_test` → `Shell.cpp` anon namespace
- `Registry::end_of_group` → `Registry.cpp` anon namespace
- `OrderedInstaller::add_ordered_test_in_order`, `add_ordered_test_in_order_not_at_head_position` → `Ordered.cpp` anon namespace
- `CommandLineArguments::get_parameter_field` → `CommandLineArguments.cpp` anon namespace
- `String::get_empty_string` → `String.cpp` anon namespace

The Shell static data members `test_result_` and `current_test_` follow their functions into the anonymous namespace (renamed without trailing `_` to match non-member naming convention), since they were only ever accessed from `Shell.cpp`.

Not changed: `Failure`'s `create_but_was_string` etc. (`protected:`, not `private:`), and `NamedValue::equals_cross_*` (directly access private data members — free functions would require `friend` declarations).

## Related Issues

Fixes # (issue number)

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist
- [ ] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [ ] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.