### PR TITLE
Use semantically correct integer types for counts and line numbers

### DIFF
--- a/examples/include/CircularBuffer.hpp
+++ b/examples/include/CircularBuffer.hpp
@@ -1,19 +1,14 @@
 #ifndef INCLUDED_CIRCULARBUFFER_HPP
 #define INCLUDED_CIRCULARBUFFER_HPP
 
-///////////////////////////////////////////////////////////////////////////////
-//
-//  CircularBuffer.h
-//
-//  CircularBuffer is responsible for ...
-//
-///////////////////////////////////////////////////////////////////////////////
+#include <stddef.h>
+
 class Printer;
 
 class CircularBuffer
 {
 public:
-  explicit CircularBuffer(int capacity = default_capacity);
+  explicit CircularBuffer(size_t capacity = default_capacity);
   virtual ~CircularBuffer();
 
   CircularBuffer(const CircularBuffer&) = delete;
@@ -23,16 +18,16 @@ public:
   int get();
   bool is_empty() const;
   bool is_full() const;
-  int capacity() const;
-  int next(int i) const;
+  size_t capacity() const;
+  size_t next(size_t i) const;
   void print(Printer* p);
 
 private:
-  int index_{ 0 };
-  int outdex_{ 0 };
+  size_t index_{ 0 };
+  size_t outdex_{ 0 };
   int* buffer_;
-  int capacity_;
-  static constexpr int default_capacity = 5;
+  size_t capacity_;
+  static constexpr size_t default_capacity = 5;
   bool empty_{ true };
   bool full_{ false };
 };

--- a/examples/src/CircularBuffer.cpp
+++ b/examples/src/CircularBuffer.cpp
@@ -4,11 +4,11 @@
 
 #include <stddef.h>
 
-CircularBuffer::CircularBuffer(int capacity)
+CircularBuffer::CircularBuffer(size_t capacity)
   : capacity_(capacity)
 
 {
-  buffer_ = new int[static_cast<size_t>(this->capacity_)];
+  buffer_ = new int[this->capacity_];
 }
 
 CircularBuffer::~CircularBuffer()
@@ -53,12 +53,12 @@ int CircularBuffer::get()
   return result;
 }
 
-int CircularBuffer::capacity() const
+size_t CircularBuffer::capacity() const
 {
   return capacity_;
 }
 
-int CircularBuffer::next(int i) const
+size_t CircularBuffer::next(size_t i) const
 {
   if (++i >= capacity_) {
     i = 0;
@@ -70,14 +70,14 @@ void CircularBuffer::print(Printer* p)
 {
   p->print("Circular buffer content:\n<");
 
-  int print_index = outdex_;
-  int count = index_ - outdex_;
+  size_t print_index = outdex_;
+  size_t count = index_ - outdex_;
 
   if (!empty_ && (index_ <= outdex_)) {
     count = capacity_ - (outdex_ - index_);
   }
 
-  for (int i = 0; i < count; i++) {
+  for (size_t i = 0; i < count; i++) {
     p->print(buffer_[print_index]);
     print_index = next(print_index);
     if (i + 1 != count) {

--- a/examples/tests/CircularBuffer.test.cpp
+++ b/examples/tests/CircularBuffer.test.cpp
@@ -11,15 +11,15 @@ TEST_GROUP(CircularBuffer)
   void setup() override { buffer = new CircularBuffer(); }
   void teardown() override { delete buffer; }
 
-  void fill_the_queue(int seed, int how_many) const
+  void fill_the_queue(int seed, size_t how_many) const
   {
-    for (int i = 0; i < how_many; i++) {
-      buffer->put(seed + i);
+    for (size_t i = 0; i < how_many; i++) {
+      buffer->put(seed + static_cast<int>(i));
     }
   }
-  void remove_from_queue(int how_many) const
+  void remove_from_queue(size_t how_many) const
   {
-    for (int i = 0; i < how_many; i++) {
+    for (size_t i = 0; i < how_many; i++) {
       buffer->get();
     }
   }
@@ -62,8 +62,8 @@ TEST(CircularBuffer, GetPutAFew)
 
 TEST(CircularBuffer, Capacity)
 {
-  CircularBuffer b(2);
-  CHECK_EQUAL(2, b.capacity());
+  CircularBuffer b(2U);
+  CHECK_EQUAL(2U, b.capacity());
 }
 
 TEST(CircularBuffer, IsFull)
@@ -101,12 +101,12 @@ TEST(CircularBuffer, WrapAround)
 
 TEST(CircularBuffer, PutToFull)
 {
-  int capacity = buffer->capacity();
+  size_t capacity = buffer->capacity();
   fill_the_queue(900, capacity);
   buffer->put(9999);
 
-  for (int i = 0; i < buffer->capacity() - 1; i++) {
-    CHECK_EQUAL(i + 900 + 1, buffer->get());
+  for (size_t i = 0; i < buffer->capacity() - 1; i++) {
+    CHECK_EQUAL(static_cast<int>(i) + 900 + 1, buffer->get());
   }
 
   CHECK_EQUAL(9999, buffer->get());

--- a/include/mu/tiny/String.hpp
+++ b/include/mu/tiny/String.hpp
@@ -219,8 +219,6 @@ MUTINY_EXPORT size_t strlen(const char* str);
 /** @brief Return a pointer to the first @p s2 in @p s1, or null. */
 MUTINY_EXPORT const char* strstr(const char* s1, const char* s2);
 
-/** @brief Parse @p str as a signed long integer. */
-MUTINY_EXPORT long strtol(const char* str);
 /** @brief Parse @p str as an unsigned long integer. */
 MUTINY_EXPORT unsigned long strtoul(const char* str);
 /** @brief Compare @p s1 and @p s2; return negative, zero, or positive. */

--- a/include/mu/tiny/test.h
+++ b/include/mu/tiny/test.h
@@ -18,6 +18,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -294,7 +295,7 @@ extern "C"
       bool actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -310,7 +311,7 @@ extern "C"
       int actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -326,7 +327,7 @@ extern "C"
       unsigned int actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -342,7 +343,7 @@ extern "C"
       long actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -358,7 +359,7 @@ extern "C"
       unsigned long actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -374,7 +375,7 @@ extern "C"
       long long actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -390,7 +391,7 @@ extern "C"
       unsigned long long actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -408,7 +409,7 @@ extern "C"
       double threshold,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -424,7 +425,7 @@ extern "C"
       char actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -440,7 +441,7 @@ extern "C"
       unsigned char actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -456,7 +457,7 @@ extern "C"
       signed char actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -472,7 +473,7 @@ extern "C"
       const char* actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -488,7 +489,7 @@ extern "C"
       const void* actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -506,7 +507,7 @@ extern "C"
       size_t size,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -518,7 +519,7 @@ extern "C"
   MUTINY_EXPORT void mutiny_fail(
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**
@@ -534,7 +535,7 @@ extern "C"
       const char* condition_string,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
 
   /**

--- a/include/mu/tiny/test.h
+++ b/include/mu/tiny/test.h
@@ -294,7 +294,7 @@ extern "C"
       bool actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -310,7 +310,7 @@ extern "C"
       int actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -326,7 +326,7 @@ extern "C"
       unsigned int actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -342,7 +342,7 @@ extern "C"
       long actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -358,7 +358,7 @@ extern "C"
       unsigned long actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -374,7 +374,7 @@ extern "C"
       long long actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -390,7 +390,7 @@ extern "C"
       unsigned long long actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -408,7 +408,7 @@ extern "C"
       double threshold,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -424,7 +424,7 @@ extern "C"
       char actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -440,7 +440,7 @@ extern "C"
       unsigned char actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -456,7 +456,7 @@ extern "C"
       signed char actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -472,7 +472,7 @@ extern "C"
       const char* actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -488,7 +488,7 @@ extern "C"
       const void* actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -506,7 +506,7 @@ extern "C"
       size_t size,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -518,7 +518,7 @@ extern "C"
   MUTINY_EXPORT void mutiny_fail(
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**
@@ -534,7 +534,7 @@ extern "C"
       const char* condition_string,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
 
   /**

--- a/include/mu/tiny/test/CommandLineArguments.hpp
+++ b/include/mu/tiny/test/CommandLineArguments.hpp
@@ -75,7 +75,7 @@ public:
   /** @return true if `-rs` (run skipped tests) was passed. */
   bool is_run_skipped() const;
   /** @return The number of times to repeat the full test suite (`-r N`). */
-  size_t get_repeat_count() const;
+  unsigned int get_repeat_count() const;
   /** @return true if `-s` (shuffle) was passed. */
   bool is_shuffling() const;
   /** @return true if tests should run in reverse order (`-rv`). */
@@ -85,7 +85,7 @@ public:
   /** @return true if exceptions should be re-thrown after being caught. */
   bool is_rethrowing_exceptions() const;
   /** @return The seed used when shuffling (0 means time-seeded). */
-  size_t get_shuffle_seed() const;
+  unsigned int get_shuffle_seed() const;
   /** @return The head of the group filter chain, or nullptr. */
   const Filter* get_group_filters() const;
   /** @return The head of the name filter chain, or nullptr. */
@@ -112,8 +112,8 @@ private:
   bool rethrow_exceptions_{ true };
   bool shuffling_{ false };
   bool shuffling_pre_seeded_{ false };
-  size_t repeat_{ 1 };
-  size_t shuffle_seed_{ 0 };
+  unsigned int repeat_{ 1 };
+  unsigned int shuffle_seed_{ 0 };
   Filter* group_filters_{ nullptr };
   Filter* name_filters_{ nullptr };
   void set_repeat_count(int argc, const char* const* argv, int& index);

--- a/include/mu/tiny/test/ExpectFailShell.hpp
+++ b/include/mu/tiny/test/ExpectFailShell.hpp
@@ -39,7 +39,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
   ~ExpectFailShell() override = default;
   ExpectFailShell(const ExpectFailShell&) = delete;

--- a/include/mu/tiny/test/ExpectFailShell.hpp
+++ b/include/mu/tiny/test/ExpectFailShell.hpp
@@ -39,7 +39,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
   ~ExpectFailShell() override = default;
   ExpectFailShell(const ExpectFailShell&) = delete;

--- a/include/mu/tiny/test/Failure.hpp
+++ b/include/mu/tiny/test/Failure.hpp
@@ -82,13 +82,13 @@ public:
   /** @return Test case name without the group prefix. */
   virtual const String& get_test_name_only() const;
   /** @return Line number of the failing assertion. */
-  virtual int get_failure_line_number() const;
+  virtual int_least32_t get_failure_line_number() const;
   /** @return Human-readable failure description. */
   virtual const String& get_message() const;
   /** @return Source file in which the test is defined. */
   virtual const String& get_test_file_name() const;
   /** @return Line number of the TEST() macro for the failing test. */
-  virtual int get_test_line_number() const;
+  virtual int_least32_t get_test_line_number() const;
 
   /**
    * @return true if this failure represents an error (e.g. unexpected

--- a/include/mu/tiny/test/Failure.hpp
+++ b/include/mu/tiny/test/Failure.hpp
@@ -15,6 +15,8 @@
 #include "mu/tiny/export.h"
 #include "mu/tiny/features.hpp"
 
+#include <stdint.h>
+
 #if MUTINY_USE_STD_CPP_LIB
 #include <stdexcept>
 #endif
@@ -48,7 +50,7 @@ public:
   Failure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const String& the_message
   );
 
@@ -68,7 +70,7 @@ public:
    * @param file_name    Source file of the failing assertion.
    * @param line_number  Line number of the failing assertion.
    */
-  Failure(Shell* test, const char* file_name, int line_number);
+  Failure(Shell* test, const char* file_name, int_least32_t line_number);
   Failure(const Failure&) = default;
   Failure(Failure&& other) noexcept;
   virtual ~Failure() = default;
@@ -163,7 +165,7 @@ public:
   EqualsFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const char* expected,
       const char* actual,
       const String& text
@@ -179,7 +181,7 @@ public:
   EqualsFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const String& expected,
       const String& actual,
       const String& text
@@ -211,7 +213,7 @@ public:
   ApproxEqualFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       T expected,
       T actual,
       T threshold,
@@ -249,7 +251,7 @@ public:
   CheckEqualFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const String& expected,
       const String& actual,
       const String& text
@@ -273,7 +275,7 @@ public:
   ComparisonFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const String& check_string,
       const String& comparison_string,
       const String& text
@@ -298,7 +300,7 @@ public:
   ContainsFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const String& expected,
       const String& actual,
       const String& text
@@ -322,7 +324,7 @@ public:
   CheckFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const String& check_string,
       const String& condition_string,
       const String& text_string = ""
@@ -344,7 +346,7 @@ public:
   FailFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const String& message
   );
 };
@@ -370,7 +372,7 @@ public:
   IntMaxEqualFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       long long expected,
       long long actual,
       const String& text
@@ -397,7 +399,7 @@ public:
   UintMaxEqualFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       unsigned long long expected,
       unsigned long long actual,
       const String& text
@@ -421,7 +423,7 @@ public:
   StringEqualFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const char* expected,
       const char* actual,
       const String& text
@@ -445,7 +447,7 @@ public:
   StringEqualNoCaseFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const char* expected,
       const char* actual,
       const String& text
@@ -470,7 +472,7 @@ public:
   BinaryEqualFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const unsigned char* expected,
       const unsigned char* actual,
       size_t size,
@@ -494,7 +496,7 @@ public:
   FeatureUnsupportedFailure(
       Shell* test,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const String& feature_name,
       const String& text
   );

--- a/include/mu/tiny/test/Failure.hpp
+++ b/include/mu/tiny/test/Failure.hpp
@@ -48,7 +48,7 @@ public:
   Failure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const String& the_message
   );
 
@@ -68,7 +68,7 @@ public:
    * @param file_name    Source file of the failing assertion.
    * @param line_number  Line number of the failing assertion.
    */
-  Failure(Shell* test, const char* file_name, size_t line_number);
+  Failure(Shell* test, const char* file_name, int line_number);
   Failure(const Failure&) = default;
   Failure(Failure&& other) noexcept;
   virtual ~Failure() = default;
@@ -80,13 +80,13 @@ public:
   /** @return Test case name without the group prefix. */
   virtual const String& get_test_name_only() const;
   /** @return Line number of the failing assertion. */
-  virtual size_t get_failure_line_number() const;
+  virtual int get_failure_line_number() const;
   /** @return Human-readable failure description. */
   virtual const String& get_message() const;
   /** @return Source file in which the test is defined. */
   virtual const String& get_test_file_name() const;
   /** @return Line number of the TEST() macro for the failing test. */
-  virtual size_t get_test_line_number() const;
+  virtual int get_test_line_number() const;
 
   /**
    * @return true if this failure represents an error (e.g. unexpected
@@ -138,9 +138,9 @@ protected:
   String test_name_;
   String test_name_only_;
   String file_name_;
-  size_t line_number_;
+  int line_number_;
   String test_file_name_;
-  size_t test_line_number_;
+  int test_line_number_;
   String message_;
 
   Failure& operator=(const Failure&);
@@ -163,7 +163,7 @@ public:
   EqualsFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const char* expected,
       const char* actual,
       const String& text
@@ -179,7 +179,7 @@ public:
   EqualsFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const String& expected,
       const String& actual,
       const String& text
@@ -211,7 +211,7 @@ public:
   ApproxEqualFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       T expected,
       T actual,
       T threshold,
@@ -249,7 +249,7 @@ public:
   CheckEqualFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const String& expected,
       const String& actual,
       const String& text
@@ -273,7 +273,7 @@ public:
   ComparisonFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const String& check_string,
       const String& comparison_string,
       const String& text
@@ -298,7 +298,7 @@ public:
   ContainsFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const String& expected,
       const String& actual,
       const String& text
@@ -322,7 +322,7 @@ public:
   CheckFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const String& check_string,
       const String& condition_string,
       const String& text_string = ""
@@ -344,7 +344,7 @@ public:
   FailFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const String& message
   );
 };
@@ -370,7 +370,7 @@ public:
   IntMaxEqualFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       long long expected,
       long long actual,
       const String& text
@@ -397,7 +397,7 @@ public:
   UintMaxEqualFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       unsigned long long expected,
       unsigned long long actual,
       const String& text
@@ -421,7 +421,7 @@ public:
   StringEqualFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const char* expected,
       const char* actual,
       const String& text
@@ -445,7 +445,7 @@ public:
   StringEqualNoCaseFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const char* expected,
       const char* actual,
       const String& text
@@ -470,7 +470,7 @@ public:
   BinaryEqualFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const unsigned char* expected,
       const unsigned char* actual,
       size_t size,
@@ -494,7 +494,7 @@ public:
   FeatureUnsupportedFailure(
       Shell* test,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const String& feature_name,
       const String& text
   );

--- a/include/mu/tiny/test/Failure.hpp
+++ b/include/mu/tiny/test/Failure.hpp
@@ -140,9 +140,9 @@ protected:
   String test_name_;
   String test_name_only_;
   String file_name_;
-  int line_number_;
+  int_least32_t line_number_;
   String test_file_name_;
-  int test_line_number_;
+  int_least32_t test_line_number_;
   String message_;
 
   Failure& operator=(const Failure&);

--- a/include/mu/tiny/test/GroupLocation.hpp
+++ b/include/mu/tiny/test/GroupLocation.hpp
@@ -17,6 +17,7 @@
 #include "mu/tiny/export.h"
 
 #include <stddef.h>
+#include <stdint.h>
 
 namespace mu {
 namespace tiny {
@@ -41,7 +42,7 @@ public:
   GroupLocation(
       const char* group_name,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   ) noexcept;
 
   GroupLocation(const GroupLocation&) = delete;

--- a/include/mu/tiny/test/GroupLocation.hpp
+++ b/include/mu/tiny/test/GroupLocation.hpp
@@ -53,7 +53,7 @@ public:
   /** @return The source file path. */
   const char* get_file() const;
   /** @return The source line number. */
-  int get_line_number() const;
+  int_least32_t get_line_number() const;
   /** @return The next entry in the registration list, or nullptr. */
   GroupLocation* get_next() const;
 

--- a/include/mu/tiny/test/GroupLocation.hpp
+++ b/include/mu/tiny/test/GroupLocation.hpp
@@ -41,7 +41,7 @@ public:
   GroupLocation(
       const char* group_name,
       const char* file_name,
-      size_t line_number
+      int line_number
   ) noexcept;
 
   GroupLocation(const GroupLocation&) = delete;
@@ -52,7 +52,7 @@ public:
   /** @return The source file path. */
   const char* get_file() const;
   /** @return The source line number. */
-  size_t get_line_number() const;
+  int get_line_number() const;
   /** @return The next entry in the registration list, or nullptr. */
   GroupLocation* get_next() const;
 
@@ -72,7 +72,7 @@ public:
 private:
   const char* group_;
   const char* file_;
-  size_t line_number_;
+  int line_number_;
   GroupLocation* next_;
 
   static GroupLocation* head_;

--- a/include/mu/tiny/test/GroupLocation.hpp
+++ b/include/mu/tiny/test/GroupLocation.hpp
@@ -73,7 +73,7 @@ public:
 private:
   const char* group_;
   const char* file_;
-  int line_number_;
+  int_least32_t line_number_;
   GroupLocation* next_;
 
   static GroupLocation* head_;

--- a/include/mu/tiny/test/Installer.hpp
+++ b/include/mu/tiny/test/Installer.hpp
@@ -43,7 +43,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      size_t line_number
+      int line_number
   ) noexcept;
   virtual ~Installer() = default;
   Installer(const Installer&) = delete;

--- a/include/mu/tiny/test/Installer.hpp
+++ b/include/mu/tiny/test/Installer.hpp
@@ -10,6 +10,7 @@
 #include "mu/tiny/export.h"
 
 #include <stddef.h>
+#include <stdint.h>
 
 namespace mu {
 namespace tiny {
@@ -43,7 +44,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   ) noexcept;
   virtual ~Installer() = default;
   Installer(const Installer&) = delete;

--- a/include/mu/tiny/test/Ordered.hpp
+++ b/include/mu/tiny/test/Ordered.hpp
@@ -110,7 +110,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       int level
   ) noexcept;
   virtual ~OrderedInstaller() = default;

--- a/include/mu/tiny/test/Ordered.hpp
+++ b/include/mu/tiny/test/Ordered.hpp
@@ -110,7 +110,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       int level
   ) noexcept;
   virtual ~OrderedInstaller() = default;

--- a/include/mu/tiny/test/Output.hpp
+++ b/include/mu/tiny/test/Output.hpp
@@ -128,7 +128,7 @@ public:
    * @brief Print a floating-point value.
    * @param d  Value to print.
    */
-  virtual void print_double(double d);
+  virtual void print(double d);
 
   /**
    * @brief Print a test failure message.

--- a/include/mu/tiny/test/Output.hpp
+++ b/include/mu/tiny/test/Output.hpp
@@ -112,7 +112,12 @@ public:
    */
   virtual void print(int n);
 
+  /**
+   * @brief Print an unsigned integer.
+   * @param n  Value to print.
+   */
   virtual void print(unsigned int n);
+
   /**
    * @brief Print a signed integer.
    * @param n  Value to print.

--- a/include/mu/tiny/test/Output.hpp
+++ b/include/mu/tiny/test/Output.hpp
@@ -14,6 +14,8 @@
 #include "mu/tiny/String.hpp"
 #include "mu/tiny/export.h"
 
+#include <stdint.h>
+
 namespace mu {
 namespace tiny {
 namespace test {
@@ -194,7 +196,7 @@ protected:
   void print_failure_message(const String& reason);
   void print_error_in_file_on_line_formatted_for_working_environment(
       const String& test_file,
-      int line_number
+      int_least32_t line_number
   );
 
   Output(const Output&);

--- a/include/mu/tiny/test/Output.hpp
+++ b/include/mu/tiny/test/Output.hpp
@@ -108,19 +108,14 @@ public:
    * @brief Print a signed integer.
    * @param n  Value to print.
    */
-  void print(int n);
+  virtual void print(int n);
 
+  virtual void print(unsigned int n);
   /**
    * @brief Print a signed integer.
    * @param n  Value to print.
    */
   virtual void print(long n);
-
-  /**
-   * @brief Print an unsigned integer.
-   * @param n  Value to print.
-   */
-  virtual void print(size_t n);
 
   /**
    * @brief Print a floating-point value.
@@ -152,7 +147,7 @@ public:
    * @param number  Current repetition (1-based).
    * @param total   Total number of repetitions.
    */
-  virtual void print_test_run(size_t number, size_t total);
+  virtual void print_test_run(unsigned int number, unsigned int total);
 
   /**
    * @brief Override the per-test progress indicator character.

--- a/include/mu/tiny/test/Output.hpp
+++ b/include/mu/tiny/test/Output.hpp
@@ -108,6 +108,12 @@ public:
    * @brief Print a signed integer.
    * @param n  Value to print.
    */
+  void print(int n);
+
+  /**
+   * @brief Print a signed integer.
+   * @param n  Value to print.
+   */
   virtual void print(long n);
 
   /**
@@ -193,7 +199,7 @@ protected:
   void print_failure_message(const String& reason);
   void print_error_in_file_on_line_formatted_for_working_environment(
       const String& test_file,
-      size_t line_number
+      int line_number
   );
 
   Output(const Output&);

--- a/include/mu/tiny/test/Result.hpp
+++ b/include/mu/tiny/test/Result.hpp
@@ -111,17 +111,17 @@ public:
   virtual void print_very_verbose(const char* text);
 
   /** @return Total number of registered tests. */
-  size_t get_test_count() const { return test_count_; }
+  unsigned int get_test_count() const { return test_count_; }
   /** @return Number of tests that actually ran. */
-  size_t get_run_count() const { return run_count_; }
+  unsigned int get_run_count() const { return run_count_; }
   /** @return Number of assertions checked. */
-  size_t get_check_count() const { return check_count_; }
+  unsigned int get_check_count() const { return check_count_; }
   /** @return Number of tests filtered out. */
-  size_t get_filtered_out_count() const { return filtered_out_count_; }
+  unsigned int get_filtered_out_count() const { return filtered_out_count_; }
   /** @return Number of ignored tests. */
-  size_t get_skipped_count() const { return skipped_count_; }
+  unsigned int get_skipped_count() const { return skipped_count_; }
   /** @return Number of test failures. */
-  size_t get_failure_count() const { return failure_count_; }
+  unsigned int get_failure_count() const { return failure_count_; }
 
   /**
    * @return true if there were any failures, or if no tests ran and none were
@@ -148,12 +148,12 @@ public:
 
 private:
   Output& output_;
-  size_t test_count_{ 0 };
-  size_t run_count_{ 0 };
-  size_t check_count_{ 0 };
-  size_t failure_count_{ 0 };
-  size_t filtered_out_count_{ 0 };
-  size_t skipped_count_{ 0 };
+  unsigned int test_count_{ 0 };
+  unsigned int run_count_{ 0 };
+  unsigned int check_count_{ 0 };
+  unsigned int failure_count_{ 0 };
+  unsigned int filtered_out_count_{ 0 };
+  unsigned int skipped_count_{ 0 };
   uint_least64_t total_execution_time_{ 0 };
   uint_least64_t time_started_{ 0 };
   uint_least64_t current_test_time_started_{ 0 };

--- a/include/mu/tiny/test/Shell.hpp
+++ b/include/mu/tiny/test/Shell.hpp
@@ -414,7 +414,7 @@ private:
   const char* group_;
   const char* name_;
   const char* file_;
-  int line_number_;
+  int_least32_t line_number_;
   Shell* next_;
   bool has_failed_;
 

--- a/include/mu/tiny/test/Shell.hpp
+++ b/include/mu/tiny/test/Shell.hpp
@@ -130,7 +130,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   ) noexcept;
   virtual ~Shell() = default;
 
@@ -178,7 +178,7 @@ public:
       const char* condition_string,
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert two C strings are equal (strcmp). */
@@ -187,7 +187,7 @@ public:
       const char* actual,
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert first @p length bytes of two C strings match.
@@ -198,7 +198,7 @@ public:
       size_t length,
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert @p actual contains the substring @p expected.
@@ -208,7 +208,7 @@ public:
       const char* actual,
       const char* text,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   );
   /**
    * @brief C-interface backend: assert two signed integer values are equal.
@@ -221,7 +221,7 @@ public:
       intmax_t actual,
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /**
@@ -235,7 +235,7 @@ public:
       uintmax_t actual,
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert two pointers are equal. */
@@ -244,7 +244,7 @@ public:
       const void* actual,
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /**
@@ -259,7 +259,7 @@ public:
       T threshold,
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   )
   {
@@ -278,7 +278,7 @@ public:
       const char* actual,
       const char* text,
       const char* file,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: generic equality failure with String arguments. */
@@ -288,7 +288,7 @@ public:
       String actual,
       const char* text,
       const char* file,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert @p length bytes of two memory regions match.
@@ -299,7 +299,7 @@ public:
       size_t length,
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert a relational comparison holds. */
@@ -309,7 +309,7 @@ public:
       const char* comparison_string,
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /**
@@ -323,7 +323,7 @@ public:
   virtual void fail(
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /**
@@ -346,7 +346,7 @@ public:
   virtual void skip_test(
       const char* text,
       const char* file_name,
-      int line_number,
+      int_least32_t line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
 
@@ -357,7 +357,7 @@ public:
    * tests). */
   void set_file_name(const char* file_name);
   /** @brief Update the source line stored in this shell. */
-  void set_line_number(int line_number);
+  void set_line_number(int_least32_t line_number);
   /** @brief Update the group name stored in this shell. */
   void set_group_name(const char* group_name);
   /** @brief Update the test name stored in this shell. */
@@ -455,7 +455,7 @@ void check_equal(
     const U& actual,
     const char* text,
     const char* file,
-    int line
+    int_least32_t line
 )
 {
   // Compare with the natural types so that mixed signed/unsigned comparisons
@@ -497,7 +497,7 @@ void check_compare(
     const char* relop_str,
     const char* text,
     const char* file,
-    int line
+    int_least32_t line
 )
 {
   // The bool result of the relop is pre-computed at the call site (in the
@@ -538,7 +538,7 @@ void check_enum_equal(
     ENUM_TYPE actual,
     const char* text,
     const char* file,
-    int line
+    int_least32_t line
 )
 {
   auto e = static_cast<UNDERLYING_TYPE>(expected);
@@ -573,7 +573,7 @@ void check_approx(
     T threshold,
     const char* text,
     const char* file,
-    int line
+    int_least32_t line
 )
 {
   if (!approx_equal(expected, actual, threshold)) {

--- a/include/mu/tiny/test/Shell.hpp
+++ b/include/mu/tiny/test/Shell.hpp
@@ -161,7 +161,7 @@ public:
   /** @return The source file path for this test. */
   const char* get_file() const;
   /** @return The source line number for this test. */
-  int get_line_number() const;
+  int_least32_t get_line_number() const;
   /** @return true if the test will actually run (not ignored). */
   virtual bool will_run() const;
   /** @return true if the test has recorded at least one failure. */

--- a/include/mu/tiny/test/Shell.hpp
+++ b/include/mu/tiny/test/Shell.hpp
@@ -130,7 +130,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      size_t line_number
+      int line_number
   ) noexcept;
   virtual ~Shell() = default;
 
@@ -161,7 +161,7 @@ public:
   /** @return The source file path for this test. */
   const char* get_file() const;
   /** @return The source line number for this test. */
-  size_t get_line_number() const;
+  int get_line_number() const;
   /** @return true if the test will actually run (not ignored). */
   virtual bool will_run() const;
   /** @return true if the test has recorded at least one failure. */
@@ -178,7 +178,7 @@ public:
       const char* condition_string,
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert two C strings are equal (strcmp). */
@@ -187,7 +187,7 @@ public:
       const char* actual,
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert first @p length bytes of two C strings match.
@@ -198,7 +198,7 @@ public:
       size_t length,
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert @p actual contains the substring @p expected.
@@ -208,7 +208,7 @@ public:
       const char* actual,
       const char* text,
       const char* file_name,
-      size_t line_number
+      int line_number
   );
   /**
    * @brief C-interface backend: assert two signed integer values are equal.
@@ -221,7 +221,7 @@ public:
       intmax_t actual,
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /**
@@ -235,7 +235,7 @@ public:
       uintmax_t actual,
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert two pointers are equal. */
@@ -244,7 +244,7 @@ public:
       const void* actual,
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /**
@@ -259,7 +259,7 @@ public:
       T threshold,
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   )
   {
@@ -278,7 +278,7 @@ public:
       const char* actual,
       const char* text,
       const char* file,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: generic equality failure with String arguments. */
@@ -288,7 +288,7 @@ public:
       String actual,
       const char* text,
       const char* file,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert @p length bytes of two memory regions match.
@@ -299,7 +299,7 @@ public:
       size_t length,
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /** @brief Macro backend: assert a relational comparison holds. */
@@ -309,7 +309,7 @@ public:
       const char* comparison_string,
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /**
@@ -323,7 +323,7 @@ public:
   virtual void fail(
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
   /**
@@ -346,7 +346,7 @@ public:
   virtual void skip_test(
       const char* text,
       const char* file_name,
-      size_t line_number,
+      int line_number,
       const Terminator& test_terminator = get_current_test_terminator()
   );
 
@@ -357,7 +357,7 @@ public:
    * tests). */
   void set_file_name(const char* file_name);
   /** @brief Update the source line stored in this shell. */
-  void set_line_number(size_t line_number);
+  void set_line_number(int line_number);
   /** @brief Update the group name stored in this shell. */
   void set_group_name(const char* group_name);
   /** @brief Update the test name stored in this shell. */
@@ -414,7 +414,7 @@ private:
   const char* group_;
   const char* name_;
   const char* file_;
-  size_t line_number_;
+  int line_number_;
   Shell* next_;
   bool has_failed_;
 
@@ -455,7 +455,7 @@ void check_equal(
     const U& actual,
     const char* text,
     const char* file,
-    size_t line
+    int line
 )
 {
   // Compare with the natural types so that mixed signed/unsigned comparisons
@@ -497,7 +497,7 @@ void check_compare(
     const char* relop_str,
     const char* text,
     const char* file,
-    size_t line
+    int line
 )
 {
   // The bool result of the relop is pre-computed at the call site (in the
@@ -538,7 +538,7 @@ void check_enum_equal(
     ENUM_TYPE actual,
     const char* text,
     const char* file,
-    size_t line
+    int line
 )
 {
   auto e = static_cast<UNDERLYING_TYPE>(expected);
@@ -573,7 +573,7 @@ void check_approx(
     T threshold,
     const char* text,
     const char* file,
-    size_t line
+    int line
 )
 {
   if (!approx_equal(expected, actual, threshold)) {

--- a/include/mu/tiny/test/SkippedShell.hpp
+++ b/include/mu/tiny/test/SkippedShell.hpp
@@ -41,7 +41,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   ) noexcept;
   SkippedShell(const SkippedShell&) = delete;
   SkippedShell& operator=(const SkippedShell&) = delete;

--- a/include/mu/tiny/test/SkippedShell.hpp
+++ b/include/mu/tiny/test/SkippedShell.hpp
@@ -41,7 +41,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      size_t line_number
+      int line_number
   ) noexcept;
   SkippedShell(const SkippedShell&) = delete;
   SkippedShell& operator=(const SkippedShell&) = delete;

--- a/include/mu/tiny/test/TestingFixture.hpp
+++ b/include/mu/tiny/test/TestingFixture.hpp
@@ -131,7 +131,7 @@ public:
   void check_test_fails_with_proper_test_location(
       const char* text,
       const char* file,
-      size_t line
+      int line
   );
 
   /**

--- a/include/mu/tiny/test/TestingFixture.hpp
+++ b/include/mu/tiny/test/TestingFixture.hpp
@@ -92,15 +92,15 @@ public:
   void run_all_tests();
 
   /** @return Number of failures recorded so far. */
-  size_t get_failure_count();
+  unsigned int get_failure_count();
   /** @return Number of assertions checked so far. */
-  size_t get_check_count();
+  unsigned int get_check_count();
   /** @return Number of ignored tests. */
-  size_t get_skip_count();
+  unsigned int get_skip_count();
   /** @return Number of tests that actually ran. */
-  size_t get_run_count();
+  unsigned int get_run_count();
   /** @return Total number of registered tests. */
-  size_t get_test_count();
+  unsigned int get_test_count();
   /** @return The accumulated output string. */
   const String& get_output();
   /** @return The private Registry. */

--- a/include/mu/tiny/test/TestingFixture.hpp
+++ b/include/mu/tiny/test/TestingFixture.hpp
@@ -131,7 +131,7 @@ public:
   void check_test_fails_with_proper_test_location(
       const char* text,
       const char* file,
-      int line
+      int_least32_t line
   );
 
   /**

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -438,29 +438,6 @@ void string_replace(String& str, const char* from, const char* to)
   str = result;
 }
 
-long strtol(const char* str)
-{
-#if MUTINY_USE_STD_STRING
-  return std::strtol(str, nullptr, decimal_base);
-#else
-  while (is_space(*str)) {
-    str++;
-  }
-
-  char first_char = *str;
-  if (first_char == '-' || first_char == '+') {
-    str++;
-  }
-
-  long result = 0;
-  for (; is_digit(*str); str++) {
-    result *= decimal_base;
-    result += *str - '0';
-  }
-  return (first_char == '-') ? -result : result;
-#endif
-}
-
 unsigned long strtoul(const char* str)
 {
 #if MUTINY_USE_STD_STRING

--- a/src/StringCollection.cpp
+++ b/src/StringCollection.cpp
@@ -3,9 +3,9 @@
 namespace mu {
 namespace tiny {
 namespace {
-size_t count_substr(const String& string, const String& substr)
+unsigned int count_substr(const String& string, const String& substr)
 {
-  size_t num = 0;
+  unsigned int num = 0;
   const char* str = string.c_str();
   const char* strpart = nullptr;
   if (*str != 0) {
@@ -36,8 +36,8 @@ void StringCollection::split_string(String const& string, char d)
 {
   auto delimiter = string_from(d);
 
-  size_t num = count_substr(string, delimiter);
-  size_t extra_end_token = (string_ends_with(string, delimiter)) ? 0 : 1U;
+  unsigned int num = count_substr(string, delimiter);
+  unsigned int extra_end_token = (string_ends_with(string, delimiter)) ? 0 : 1U;
   allocate(num + extra_end_token);
 
   const char* str = string.c_str();

--- a/src/mu/tiny/test/CompositeOutput.hpp
+++ b/src/mu/tiny/test/CompositeOutput.hpp
@@ -29,7 +29,8 @@ public:
   void print_buffer(const char* buffer) override;
   void print(const char* buffer) override;
   void print(long number) override;
-  void print(size_t number) override;
+  void print(int number) override;
+  void print(unsigned int number) override;
   void print_double(double number) override;
   void print_failure(const Failure& failure) override;
   void set_progress_indicator(const char* indicator) override;

--- a/src/mu/tiny/test/CompositeOutput.hpp
+++ b/src/mu/tiny/test/CompositeOutput.hpp
@@ -31,7 +31,7 @@ public:
   void print(long number) override;
   void print(int number) override;
   void print(unsigned int number) override;
-  void print_double(double number) override;
+  void print(double number) override;
   void print_failure(const Failure& failure) override;
   void set_progress_indicator(const char* indicator) override;
 

--- a/src/test/CommandLineArguments.cpp
+++ b/src/test/CommandLineArguments.cpp
@@ -348,7 +348,7 @@ bool CommandLineArguments::is_run_skipped() const
   return run_skipped_;
 }
 
-size_t CommandLineArguments::get_repeat_count() const
+unsigned int CommandLineArguments::get_repeat_count() const
 {
   return repeat_;
 }
@@ -373,7 +373,7 @@ bool CommandLineArguments::is_shuffling() const
   return shuffling_;
 }
 
-size_t CommandLineArguments::get_shuffle_seed() const
+unsigned int CommandLineArguments::get_shuffle_seed() const
 {
   return shuffle_seed_;
 }
@@ -398,9 +398,9 @@ void CommandLineArguments::set_repeat_count(
 
   String repeat_parameter(argv[i]);
   if (repeat_parameter.size() > 2) {
-    repeat_ = static_cast<size_t>(strtol(argv[i] + 2));
+    repeat_ = static_cast<unsigned int>(strtol(argv[i] + 2));
   } else if (i + 1 < argc) {
-    repeat_ = static_cast<size_t>(strtol(argv[i + 1]));
+    repeat_ = static_cast<unsigned int>(strtol(argv[i + 1]));
     if (repeat_ != 0) {
       i++;
     }

--- a/src/test/CommandLineArguments.cpp
+++ b/src/test/CommandLineArguments.cpp
@@ -398,9 +398,9 @@ void CommandLineArguments::set_repeat_count(
 
   String repeat_parameter(argv[i]);
   if (repeat_parameter.size() > 2) {
-    repeat_ = static_cast<unsigned int>(strtol(argv[i] + 2));
+    repeat_ = static_cast<unsigned int>(strtoul(argv[i] + 2));
   } else if (i + 1 < argc) {
-    repeat_ = static_cast<unsigned int>(strtol(argv[i + 1]));
+    repeat_ = static_cast<unsigned int>(strtoul(argv[i + 1]));
     if (repeat_ != 0) {
       i++;
     }

--- a/src/test/CommandLineRunner.cpp
+++ b/src/test/CommandLineRunner.cpp
@@ -99,10 +99,10 @@ void CommandLineRunner::initialize_test_run()
 int CommandLineRunner::run_all_tests()
 {
   initialize_test_run();
-  size_t loop_count = 0;
-  size_t failed_test_count = 0;
-  size_t failed_execution_count = 0;
-  size_t repeat_count = arguments_->get_repeat_count();
+  unsigned int loop_count = 0;
+  unsigned int failed_test_count = 0;
+  unsigned int failed_execution_count = 0;
+  auto repeat_count = arguments_->get_repeat_count();
 
   if (arguments_->is_listing_test_group_names()) {
     Result tr(*output_);

--- a/src/test/CompositeOutput.cpp
+++ b/src/test/CompositeOutput.cpp
@@ -132,7 +132,17 @@ void CompositeOutput::print(long number)
   }
 }
 
-void CompositeOutput::print(size_t number)
+void CompositeOutput::print(int number)
+{
+  if (output_one_ != nullptr) {
+    output_one_->print(number);
+  }
+  if (output_two_ != nullptr) {
+    output_two_->print(number);
+  }
+}
+
+void CompositeOutput::print(unsigned int number)
 {
   if (output_one_ != nullptr) {
     output_one_->print(number);

--- a/src/test/CompositeOutput.cpp
+++ b/src/test/CompositeOutput.cpp
@@ -152,13 +152,13 @@ void CompositeOutput::print(unsigned int number)
   }
 }
 
-void CompositeOutput::print_double(double number)
+void CompositeOutput::print(double number)
 {
   if (output_one_ != nullptr) {
-    output_one_->print_double(number);
+    output_one_->print(number);
   }
   if (output_two_ != nullptr) {
-    output_two_->print_double(number);
+    output_two_->print(number);
   }
 }
 

--- a/src/test/ExpectFailShell.cpp
+++ b/src/test/ExpectFailShell.cpp
@@ -13,7 +13,7 @@ ExpectFailShell::ExpectFailShell(
     const char* group_name,
     const char* test_name,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
   : Shell(group_name, test_name, file_name, line_number)
 {

--- a/src/test/ExpectFailShell.cpp
+++ b/src/test/ExpectFailShell.cpp
@@ -13,7 +13,7 @@ ExpectFailShell::ExpectFailShell(
     const char* group_name,
     const char* test_name,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
   : Shell(group_name, test_name, file_name, line_number)
 {

--- a/src/test/Failure.cpp
+++ b/src/test/Failure.cpp
@@ -83,7 +83,7 @@ String printable_string_from_or_null(const char* expected)
 Failure::Failure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const String& the_message
 )
   : test_name_(test->get_formatted_name())
@@ -107,7 +107,7 @@ Failure::Failure(Shell* test, const String& the_message)
 {
 }
 
-Failure::Failure(Shell* test, const char* file_name, int line_num)
+Failure::Failure(Shell* test, const char* file_name, int_least32_t line_num)
   : test_name_(test->get_formatted_name())
   , test_name_only_(test->get_name())
   , file_name_(file_name)
@@ -149,12 +149,12 @@ const String& Failure::get_test_name_only() const
   return test_name_only_;
 }
 
-int Failure::get_failure_line_number() const
+int_least32_t Failure::get_failure_line_number() const
 {
   return line_number_;
 }
 
-int Failure::get_test_line_number() const
+int_least32_t Failure::get_test_line_number() const
 {
   return test_line_number_;
 }
@@ -233,7 +233,7 @@ String Failure::create_user_text(const String& text)
 EqualsFailure::EqualsFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const char* expected,
     const char* actual,
     const String& text
@@ -250,7 +250,7 @@ EqualsFailure::EqualsFailure(
 EqualsFailure::EqualsFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const String& expected,
     const String& actual,
     const String& text
@@ -265,7 +265,7 @@ EqualsFailure::EqualsFailure(
 CheckEqualFailure::CheckEqualFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const String& expected,
     const String& actual,
     const String& text
@@ -296,7 +296,7 @@ CheckEqualFailure::CheckEqualFailure(
 ComparisonFailure::ComparisonFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const String& check_string,
     const String& comparison_string,
     const String& text
@@ -313,7 +313,7 @@ ComparisonFailure::ComparisonFailure(
 ContainsFailure::ContainsFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const String& expected,
     const String& actual,
     const String& text
@@ -330,7 +330,7 @@ ContainsFailure::ContainsFailure(
 CheckFailure::CheckFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const String& check_string,
     const String& condition_string,
     const String& text
@@ -348,7 +348,7 @@ CheckFailure::CheckFailure(
 FailFailure::FailFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const String& message
 )
   : Failure(test, file_name, line_number)
@@ -359,7 +359,7 @@ FailFailure::FailFailure(
 IntMaxEqualFailure::IntMaxEqualFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     long long expected,
     long long actual,
     const String& text
@@ -383,7 +383,7 @@ IntMaxEqualFailure::IntMaxEqualFailure(
 UintMaxEqualFailure::UintMaxEqualFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     unsigned long long expected,
     unsigned long long actual,
     const String& text
@@ -407,7 +407,7 @@ UintMaxEqualFailure::UintMaxEqualFailure(
 StringEqualFailure::StringEqualFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const char* expected,
     const char* actual,
     const String& text
@@ -439,7 +439,7 @@ StringEqualFailure::StringEqualFailure(
 StringEqualNoCaseFailure::StringEqualNoCaseFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const char* expected,
     const char* actual,
     const String& text
@@ -473,7 +473,7 @@ StringEqualNoCaseFailure::StringEqualNoCaseFailure(
 BinaryEqualFailure::BinaryEqualFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const unsigned char* expected,
     const unsigned char* actual,
     size_t size,
@@ -502,7 +502,7 @@ BinaryEqualFailure::BinaryEqualFailure(
 FeatureUnsupportedFailure::FeatureUnsupportedFailure(
     Shell* test,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const String& feature_name,
     const String& text
 )

--- a/src/test/Failure.cpp
+++ b/src/test/Failure.cpp
@@ -83,7 +83,7 @@ String printable_string_from_or_null(const char* expected)
 Failure::Failure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const String& the_message
 )
   : test_name_(test->get_formatted_name())
@@ -107,7 +107,7 @@ Failure::Failure(Shell* test, const String& the_message)
 {
 }
 
-Failure::Failure(Shell* test, const char* file_name, size_t line_num)
+Failure::Failure(Shell* test, const char* file_name, int line_num)
   : test_name_(test->get_formatted_name())
   , test_name_only_(test->get_name())
   , file_name_(file_name)
@@ -149,12 +149,12 @@ const String& Failure::get_test_name_only() const
   return test_name_only_;
 }
 
-size_t Failure::get_failure_line_number() const
+int Failure::get_failure_line_number() const
 {
   return line_number_;
 }
 
-size_t Failure::get_test_line_number() const
+int Failure::get_test_line_number() const
 {
   return test_line_number_;
 }
@@ -233,7 +233,7 @@ String Failure::create_user_text(const String& text)
 EqualsFailure::EqualsFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const char* expected,
     const char* actual,
     const String& text
@@ -250,7 +250,7 @@ EqualsFailure::EqualsFailure(
 EqualsFailure::EqualsFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const String& expected,
     const String& actual,
     const String& text
@@ -265,7 +265,7 @@ EqualsFailure::EqualsFailure(
 CheckEqualFailure::CheckEqualFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const String& expected,
     const String& actual,
     const String& text
@@ -296,7 +296,7 @@ CheckEqualFailure::CheckEqualFailure(
 ComparisonFailure::ComparisonFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const String& check_string,
     const String& comparison_string,
     const String& text
@@ -313,7 +313,7 @@ ComparisonFailure::ComparisonFailure(
 ContainsFailure::ContainsFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const String& expected,
     const String& actual,
     const String& text
@@ -330,7 +330,7 @@ ContainsFailure::ContainsFailure(
 CheckFailure::CheckFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const String& check_string,
     const String& condition_string,
     const String& text
@@ -348,7 +348,7 @@ CheckFailure::CheckFailure(
 FailFailure::FailFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const String& message
 )
   : Failure(test, file_name, line_number)
@@ -359,7 +359,7 @@ FailFailure::FailFailure(
 IntMaxEqualFailure::IntMaxEqualFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     long long expected,
     long long actual,
     const String& text
@@ -383,7 +383,7 @@ IntMaxEqualFailure::IntMaxEqualFailure(
 UintMaxEqualFailure::UintMaxEqualFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     unsigned long long expected,
     unsigned long long actual,
     const String& text
@@ -407,7 +407,7 @@ UintMaxEqualFailure::UintMaxEqualFailure(
 StringEqualFailure::StringEqualFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const char* expected,
     const char* actual,
     const String& text
@@ -439,7 +439,7 @@ StringEqualFailure::StringEqualFailure(
 StringEqualNoCaseFailure::StringEqualNoCaseFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const char* expected,
     const char* actual,
     const String& text
@@ -473,7 +473,7 @@ StringEqualNoCaseFailure::StringEqualNoCaseFailure(
 BinaryEqualFailure::BinaryEqualFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const unsigned char* expected,
     const unsigned char* actual,
     size_t size,
@@ -502,7 +502,7 @@ BinaryEqualFailure::BinaryEqualFailure(
 FeatureUnsupportedFailure::FeatureUnsupportedFailure(
     Shell* test,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const String& feature_name,
     const String& text
 )

--- a/src/test/GroupLocation.cpp
+++ b/src/test/GroupLocation.cpp
@@ -9,7 +9,7 @@ GroupLocation* GroupLocation::head_ = nullptr;
 GroupLocation::GroupLocation(
     const char* group_name,
     const char* file_name,
-    size_t line_number
+    int line_number
 ) noexcept
   : group_(group_name)
   , file_(file_name)
@@ -29,7 +29,7 @@ const char* GroupLocation::get_file() const
   return file_;
 }
 
-size_t GroupLocation::get_line_number() const
+int GroupLocation::get_line_number() const
 {
   return line_number_;
 }

--- a/src/test/GroupLocation.cpp
+++ b/src/test/GroupLocation.cpp
@@ -9,7 +9,7 @@ GroupLocation* GroupLocation::head_ = nullptr;
 GroupLocation::GroupLocation(
     const char* group_name,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 ) noexcept
   : group_(group_name)
   , file_(file_name)
@@ -29,7 +29,7 @@ const char* GroupLocation::get_file() const
   return file_;
 }
 
-int GroupLocation::get_line_number() const
+int_least32_t GroupLocation::get_line_number() const
 {
   return line_number_;
 }

--- a/src/test/Installer.cpp
+++ b/src/test/Installer.cpp
@@ -12,7 +12,7 @@ Installer::Installer(
     const char* group_name,
     const char* test_name,
     const char* file_name,
-    size_t line_number
+    int line_number
 ) noexcept
 {
   shell.set_group_name(group_name);

--- a/src/test/Installer.cpp
+++ b/src/test/Installer.cpp
@@ -12,7 +12,7 @@ Installer::Installer(
     const char* group_name,
     const char* test_name,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 ) noexcept
 {
   shell.set_group_name(group_name);

--- a/src/test/JUnitOutput.cpp
+++ b/src/test/JUnitOutput.cpp
@@ -38,7 +38,7 @@ public:
   bool skipped{ false };
   String skip_message;
   String file;
-  size_t line_number{ 0 };
+  int line_number{ 0 };
   size_t check_count{ 0 };
   TestProperty* properties{ nullptr };
   TestProperty* properties_tail{ nullptr };
@@ -272,7 +272,7 @@ void JUnitOutput::write_test_cases()
         static_cast<int>(cur->exec_time / ms_per_s),
         static_cast<int>(cur->exec_time % ms_per_s),
         cur->file.c_str(),
-        static_cast<int>(cur->line_number)
+        cur->line_number
     );
     write_to_file(buf.c_str());
 
@@ -323,10 +323,10 @@ void JUnitOutput::write_failure(JUnitTestCaseResultNode* node)
       "<failure message=\"%s:%d: %s\" type=\"AssertionFailedError\">\n"
       "%s:%d: %s\n",
       file.c_str(),
-      static_cast<int>(node->failure->get_failure_line_number()),
+      node->failure->get_failure_line_number(),
       msg.c_str(),
       file.c_str(),
-      static_cast<int>(node->failure->get_failure_line_number()),
+      node->failure->get_failure_line_number(),
       msg.c_str()
   );
   write_to_file(buf.c_str());

--- a/src/test/JUnitOutput.cpp
+++ b/src/test/JUnitOutput.cpp
@@ -38,7 +38,7 @@ public:
   bool skipped{ false };
   String skip_message;
   String file;
-  int line_number{ 0 };
+  int_least32_t line_number{ 0 };
   unsigned int check_count{ 0 };
   TestProperty* properties{ nullptr };
   TestProperty* properties_tail{ nullptr };

--- a/src/test/JUnitOutput.cpp
+++ b/src/test/JUnitOutput.cpp
@@ -39,7 +39,7 @@ public:
   String skip_message;
   String file;
   int line_number{ 0 };
-  size_t check_count{ 0 };
+  unsigned int check_count{ 0 };
   TestProperty* properties{ nullptr };
   TestProperty* properties_tail{ nullptr };
   JUnitTestCaseResultNode* next{ nullptr };
@@ -50,11 +50,11 @@ class JUnitTestGroupResult
 public:
   JUnitTestGroupResult() = default;
 
-  size_t test_count{ 0 };
-  size_t failure_count{ 0 };
-  size_t error_count{ 0 };
-  size_t skip_count{ 0 };
-  size_t total_check_count{ 0 };
+  unsigned int test_count{ 0 };
+  unsigned int failure_count{ 0 };
+  unsigned int error_count{ 0 };
+  unsigned int skip_count{ 0 };
+  unsigned int total_check_count{ 0 };
   uint_least64_t start_time{ 0 };
   uint_least64_t group_exec_time{ 0 };
   String group;
@@ -69,10 +69,10 @@ public:
   String current_group_xml;
   String accumulated_xml;
   String package;
-  size_t total_test_count{ 0 };
-  size_t total_failure_count{ 0 };
-  size_t total_error_count{ 0 };
-  size_t total_skip_count{ 0 };
+  unsigned int total_test_count{ 0 };
+  unsigned int total_failure_count{ 0 };
+  unsigned int total_error_count{ 0 };
+  unsigned int total_skip_count{ 0 };
   uint_least64_t total_exec_time{ 0 };
   String start_timestamp;
 };
@@ -221,7 +221,7 @@ void JUnitOutput::set_package_name(const String& package)
 
 void JUnitOutput::write_test_suite_summary()
 {
-  size_t total_assertions = 0;
+  unsigned int total_assertions = 0;
   for (JUnitTestCaseResultNode* n = impl_->results.head; n != nullptr;
        n = n->next) {
     total_assertions = n->check_count;

--- a/src/test/JUnitOutput.cpp
+++ b/src/test/JUnitOutput.cpp
@@ -7,7 +7,7 @@
 
 #include "mu/tiny/time.hpp"
 
-#include <stdint.h>
+#include <inttypes.h>
 
 namespace mu {
 namespace tiny {
@@ -263,7 +263,7 @@ void JUnitOutput::write_test_cases()
   while (cur != nullptr) {
     String buf = string_from_format(
         "<testcase classname=\"%s%s%s\" name=\"%s\" assertions=\"%d\" "
-        "time=\"%d.%03d\" file=\"%s\" line=\"%d\">\n",
+        "time=\"%d.%03d\" file=\"%s\" line=\"%" PRIdLEAST32 "\">\n",
         impl_->package.c_str(),
         impl_->package.empty() ? "" : ".",
         impl_->results.group.c_str(),
@@ -320,8 +320,9 @@ void JUnitOutput::write_failure(JUnitTestCaseResultNode* node)
   String file = encode_xml_text(node->failure->get_file_name());
   String msg = encode_xml_text(node->failure->get_message());
   String buf = string_from_format(
-      "<failure message=\"%s:%d: %s\" type=\"AssertionFailedError\">\n"
-      "%s:%d: %s\n",
+      "<failure message=\"%s:%" PRIdLEAST32
+      ": %s\" type=\"AssertionFailedError\">\n"
+      "%s:%" PRIdLEAST32 ": %s\n",
       file.c_str(),
       node->failure->get_failure_line_number(),
       msg.c_str(),

--- a/src/test/Ordered.cpp
+++ b/src/test/Ordered.cpp
@@ -100,7 +100,7 @@ OrderedInstaller::OrderedInstaller(
     const char* group_name,
     const char* test_name,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     int level
 ) noexcept
 {

--- a/src/test/Ordered.cpp
+++ b/src/test/Ordered.cpp
@@ -100,7 +100,7 @@ OrderedInstaller::OrderedInstaller(
     const char* group_name,
     const char* test_name,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     int level
 ) noexcept
 {

--- a/src/test/Output.cpp
+++ b/src/test/Output.cpp
@@ -55,6 +55,11 @@ void Output::print(const char* str)
   print_buffer(str);
 }
 
+void Output::print(int n)
+{
+  print(static_cast<long>(n));
+}
+
 void Output::print(long n)
 {
   print(string_from(n).c_str());
@@ -238,7 +243,7 @@ void Output::print_failure_message(const String& reason)
 
 void Output::print_error_in_file_on_line_formatted_for_working_environment(
     const String& file,
-    size_t line_number
+    int line_number
 )
 {
   print("\n");

--- a/src/test/Output.cpp
+++ b/src/test/Output.cpp
@@ -60,12 +60,12 @@ void Output::print(int n)
   print(static_cast<long>(n));
 }
 
-void Output::print(long n)
+void Output::print(unsigned int n)
 {
-  print(string_from(n).c_str());
+  print(static_cast<long>(n));
 }
 
-void Output::print(size_t n)
+void Output::print(long n)
 {
   print(string_from(n).c_str());
 }
@@ -135,7 +135,7 @@ void Output::print_tests_ended(const Result& result)
 {
   print("\n");
   const bool is_failure = result.is_failure();
-  const size_t failure_count = result.get_failure_count();
+  const unsigned int failure_count = result.get_failure_count();
   if (is_failure) {
     if (color_) {
       print("\033[31;1m");
@@ -182,7 +182,7 @@ void Output::print_tests_ended(const Result& result)
   dot_count_ = 0;
 }
 
-void Output::print_test_run(size_t number, size_t total)
+void Output::print_test_run(unsigned int number, unsigned int total)
 {
   if (total > 1) {
     print("Test run ");

--- a/src/test/Output.cpp
+++ b/src/test/Output.cpp
@@ -70,7 +70,7 @@ void Output::print(long n)
   print(string_from(n).c_str());
 }
 
-void Output::print_double(double d)
+void Output::print(double d)
 {
   print(string_from(d).c_str());
 }

--- a/src/test/Output.cpp
+++ b/src/test/Output.cpp
@@ -62,7 +62,7 @@ void Output::print(int n)
 
 void Output::print(unsigned int n)
 {
-  print(static_cast<long>(n));
+  print(string_from(n).c_str());
 }
 
 void Output::print(long n)

--- a/src/test/Output.cpp
+++ b/src/test/Output.cpp
@@ -243,7 +243,7 @@ void Output::print_failure_message(const String& reason)
 
 void Output::print_error_in_file_on_line_formatted_for_working_environment(
     const String& file,
-    int line_number
+    int_least32_t line_number
 )
 {
   print("\n");

--- a/src/test/Registry.cpp
+++ b/src/test/Registry.cpp
@@ -127,8 +127,7 @@ void Registry::list_test_locations(Result& result)
     test_location += ".";
     test_location += test->get_file();
     test_location += ".";
-    test_location +=
-        string_from_format("%d\n", static_cast<int>(test->get_line_number()));
+    test_location += string_from_format("%d\n", test->get_line_number());
 
     test_locations += test_location;
   }
@@ -151,8 +150,7 @@ void Registry::list_ordered_test_locations(Result& result)
     test_location += ".";
     test_location += test->get_file();
     test_location += ".";
-    test_location +=
-        string_from_format("%d\n", static_cast<int>(test->get_line_number()));
+    test_location += string_from_format("%d\n", test->get_line_number());
 
     test_locations += test_location;
   }
@@ -171,7 +169,7 @@ void Registry::list_test_group_locations(Result& result)
     entry += ".";
     entry += g->get_file();
     entry += ".";
-    entry += string_from_format("%d\n", static_cast<int>(g->get_line_number()));
+    entry += string_from_format("%d\n", g->get_line_number());
 
     group_locations += entry;
   }

--- a/src/test/Registry.cpp
+++ b/src/test/Registry.cpp
@@ -6,6 +6,8 @@
 #include "mu/tiny/test/Shell.hpp"
 #include "mu/tiny/test/ShellPointerArray.hpp"
 
+#include <inttypes.h>
+
 namespace mu {
 namespace tiny {
 namespace test {
@@ -127,7 +129,8 @@ void Registry::list_test_locations(Result& result)
     test_location += ".";
     test_location += test->get_file();
     test_location += ".";
-    test_location += string_from_format("%d\n", test->get_line_number());
+    test_location +=
+        string_from_format("%" PRIdLEAST32 "\n", test->get_line_number());
 
     test_locations += test_location;
   }
@@ -150,7 +153,8 @@ void Registry::list_ordered_test_locations(Result& result)
     test_location += ".";
     test_location += test->get_file();
     test_location += ".";
-    test_location += string_from_format("%d\n", test->get_line_number());
+    test_location +=
+        string_from_format("%" PRIdLEAST32 "\n", test->get_line_number());
 
     test_locations += test_location;
   }
@@ -169,7 +173,7 @@ void Registry::list_test_group_locations(Result& result)
     entry += ".";
     entry += g->get_file();
     entry += ".";
-    entry += string_from_format("%d\n", g->get_line_number());
+    entry += string_from_format("%" PRIdLEAST32 "\n", g->get_line_number());
 
     group_locations += entry;
   }

--- a/src/test/Shell.cpp
+++ b/src/test/Shell.cpp
@@ -159,7 +159,7 @@ Shell::Shell(
     const char* group_name,
     const char* test_name,
     const char* file_name,
-    size_t line_number
+    int line_number
 ) noexcept
   : group_(group_name)
   , name_(test_name)
@@ -317,7 +317,7 @@ void Shell::set_file_name(const char* file_name)
   file_ = file_name;
 }
 
-void Shell::set_line_number(size_t line_number)
+void Shell::set_line_number(int line_number)
 {
   line_number_ = line_number;
 }
@@ -337,7 +337,7 @@ const char* Shell::get_file() const
   return file_;
 }
 
-size_t Shell::get_line_number() const
+int Shell::get_line_number() const
 {
   return line_number_;
 }
@@ -369,7 +369,7 @@ void Shell::exit_test(const Terminator& terminator)
 void Shell::skip_test(
     const char* text,
     const char* /*file_name*/,
-    size_t /*line_number*/,
+    int /*line_number*/,
     const Terminator& terminator
 )
 {
@@ -383,7 +383,7 @@ void Shell::assert_true(
     const char* condition_string,
     const char* text,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const Terminator& test_terminator
 )
 {
@@ -399,7 +399,7 @@ void Shell::assert_true(
 void Shell::fail(
     const char* text,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const Terminator& test_terminator
 )
 {
@@ -413,7 +413,7 @@ void Shell::assert_cstr_equal(
     const char* actual,
     const char* text,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const Terminator& test_terminator
 )
 {
@@ -441,7 +441,7 @@ void Shell::assert_cstr_n_equal(
     size_t length,
     const char* text,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const Terminator& test_terminator
 )
 {
@@ -468,7 +468,7 @@ void Shell::assert_cstr_contains(
     const char* actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   get_test_result()->count_check();
@@ -503,7 +503,7 @@ void Shell::assert_intmax_equal(
     intmax_t actual,
     const char* text,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const Terminator& test_terminator
 )
 {
@@ -521,7 +521,7 @@ void Shell::assert_uintmax_equal(
     uintmax_t actual,
     const char* text,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const Terminator& test_terminator
 )
 {
@@ -539,7 +539,7 @@ void Shell::assert_pointers_equal(
     const void* actual,
     const char* text,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const Terminator& test_terminator
 )
 {
@@ -563,7 +563,7 @@ void Shell::assert_binary_equal(
     size_t length,
     const char* text,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const Terminator& test_terminator
 )
 {
@@ -606,7 +606,7 @@ void Shell::assert_equals(
     const char* actual,
     const char* text,
     const char* file,
-    size_t line,
+    int line,
     const Terminator& test_terminator
 )
 {
@@ -623,7 +623,7 @@ void Shell::assert_equals(
     String actual,
     const char* text,
     const char* file,
-    size_t line,
+    int line,
     const Terminator& test_terminator
 )
 {
@@ -644,7 +644,7 @@ void Shell::assert_compare(
     const char* comparison_string,
     const char* text,
     const char* file_name,
-    size_t line_number,
+    int line_number,
     const Terminator& test_terminator
 )
 {

--- a/src/test/Shell.cpp
+++ b/src/test/Shell.cpp
@@ -369,7 +369,7 @@ void Shell::exit_test(const Terminator& terminator)
 void Shell::skip_test(
     const char* text,
     const char* /*file_name*/,
-    int /*line_number*/,
+    int_least32_t /*line_number*/,
     const Terminator& terminator
 )
 {

--- a/src/test/Shell.cpp
+++ b/src/test/Shell.cpp
@@ -159,7 +159,7 @@ Shell::Shell(
     const char* group_name,
     const char* test_name,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 ) noexcept
   : group_(group_name)
   , name_(test_name)
@@ -317,7 +317,7 @@ void Shell::set_file_name(const char* file_name)
   file_ = file_name;
 }
 
-void Shell::set_line_number(int line_number)
+void Shell::set_line_number(int_least32_t line_number)
 {
   line_number_ = line_number;
 }
@@ -337,7 +337,7 @@ const char* Shell::get_file() const
   return file_;
 }
 
-int Shell::get_line_number() const
+int_least32_t Shell::get_line_number() const
 {
   return line_number_;
 }
@@ -383,7 +383,7 @@ void Shell::assert_true(
     const char* condition_string,
     const char* text,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const Terminator& test_terminator
 )
 {
@@ -399,7 +399,7 @@ void Shell::assert_true(
 void Shell::fail(
     const char* text,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const Terminator& test_terminator
 )
 {
@@ -413,7 +413,7 @@ void Shell::assert_cstr_equal(
     const char* actual,
     const char* text,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const Terminator& test_terminator
 )
 {
@@ -441,7 +441,7 @@ void Shell::assert_cstr_n_equal(
     size_t length,
     const char* text,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const Terminator& test_terminator
 )
 {
@@ -468,7 +468,7 @@ void Shell::assert_cstr_contains(
     const char* actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   get_test_result()->count_check();
@@ -503,7 +503,7 @@ void Shell::assert_intmax_equal(
     intmax_t actual,
     const char* text,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const Terminator& test_terminator
 )
 {
@@ -521,7 +521,7 @@ void Shell::assert_uintmax_equal(
     uintmax_t actual,
     const char* text,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const Terminator& test_terminator
 )
 {
@@ -539,7 +539,7 @@ void Shell::assert_pointers_equal(
     const void* actual,
     const char* text,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const Terminator& test_terminator
 )
 {
@@ -563,7 +563,7 @@ void Shell::assert_binary_equal(
     size_t length,
     const char* text,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const Terminator& test_terminator
 )
 {
@@ -606,7 +606,7 @@ void Shell::assert_equals(
     const char* actual,
     const char* text,
     const char* file,
-    int line,
+    int_least32_t line,
     const Terminator& test_terminator
 )
 {
@@ -623,7 +623,7 @@ void Shell::assert_equals(
     String actual,
     const char* text,
     const char* file,
-    int line,
+    int_least32_t line,
     const Terminator& test_terminator
 )
 {
@@ -644,7 +644,7 @@ void Shell::assert_compare(
     const char* comparison_string,
     const char* text,
     const char* file_name,
-    int line_number,
+    int_least32_t line_number,
     const Terminator& test_terminator
 )
 {

--- a/src/test/SkippedShell.cpp
+++ b/src/test/SkippedShell.cpp
@@ -16,7 +16,7 @@ SkippedShell::SkippedShell(
     const char* group_name,
     const char* test_name,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 ) noexcept
   : Shell(group_name, test_name, file_name, line_number)
   , run_ignored_(false)

--- a/src/test/SkippedShell.cpp
+++ b/src/test/SkippedShell.cpp
@@ -16,7 +16,7 @@ SkippedShell::SkippedShell(
     const char* group_name,
     const char* test_name,
     const char* file_name,
-    size_t line_number
+    int line_number
 ) noexcept
   : Shell(group_name, test_name, file_name, line_number)
   , run_ignored_(false)

--- a/src/test/TapOutput.cpp
+++ b/src/test/TapOutput.cpp
@@ -60,7 +60,7 @@ class TapOutputImpl
 public:
   TapOutputImpl() = default;
 
-  size_t test_count{ 0 };
+  unsigned int test_count{ 0 };
   TapTestResultNode* head{ nullptr };
   TapTestResultNode* tail{ nullptr };
 };
@@ -126,7 +126,7 @@ void TapOutput::print_tests_ended(const Result& /*result*/)
   );
   fputs_(header.c_str(), stdout_);
 
-  size_t n = 0;
+  unsigned int n = 0;
   for (TapTestResultNode* cur = impl_->head; cur != nullptr; cur = cur->next) {
     ++n;
     String test_id = cur->group;
@@ -162,9 +162,7 @@ void TapOutput::print_tests_ended(const Result& /*result*/)
       );
       fputs_(line.c_str(), stdout_);
     } else {
-      String line = string_from_format(
-          "ok %d - %s\n", static_cast<int>(n), test_id.c_str()
-      );
+      String line = string_from_format("ok %u - %s\n", n, test_id.c_str());
       fputs_(line.c_str(), stdout_);
     }
   }

--- a/src/test/TapOutput.cpp
+++ b/src/test/TapOutput.cpp
@@ -149,8 +149,7 @@ void TapOutput::print_tests_ended(const Result& /*result*/)
           "    file: %s\n", cur->failure->get_file_name().c_str()
       );
       line += string_from_format(
-          "    line: %d\n",
-          static_cast<int>(cur->failure->get_failure_line_number())
+          "    line: %d\n", cur->failure->get_failure_line_number()
       );
       line += "  ...\n";
       fputs_(line.c_str(), stdout_);

--- a/src/test/TapOutput.cpp
+++ b/src/test/TapOutput.cpp
@@ -5,6 +5,8 @@
 #include "mu/tiny/test/Result.hpp"
 #include "mu/tiny/test/Shell.hpp"
 
+#include <inttypes.h>
+
 namespace mu {
 namespace tiny {
 namespace test {
@@ -149,7 +151,8 @@ void TapOutput::print_tests_ended(const Result& /*result*/)
           "    file: %s\n", cur->failure->get_file_name().c_str()
       );
       line += string_from_format(
-          "    line: %d\n", cur->failure->get_failure_line_number()
+          "    line: %" PRIdLEAST32 "\n",
+          cur->failure->get_failure_line_number()
       );
       line += "  ...\n";
       fputs_(line.c_str(), stdout_);

--- a/src/test/TestingFixture.cpp
+++ b/src/test/TestingFixture.cpp
@@ -167,7 +167,7 @@ void TestingFixture::line_executed_after_check()
 void TestingFixture::check_test_fails_with_proper_test_location(
     const char* text,
     const char* file,
-    int line
+    int_least32_t line
 )
 {
   if (get_failure_count() != 1) {

--- a/src/test/TestingFixture.cpp
+++ b/src/test/TestingFixture.cpp
@@ -109,22 +109,22 @@ void TestingFixture::run_all_tests()
   registry_->run_all_tests(*result_);
 }
 
-size_t TestingFixture::get_failure_count()
+unsigned int TestingFixture::get_failure_count()
 {
   return result_->get_failure_count();
 }
 
-size_t TestingFixture::get_check_count()
+unsigned int TestingFixture::get_check_count()
 {
   return result_->get_check_count();
 }
 
-size_t TestingFixture::get_test_count()
+unsigned int TestingFixture::get_test_count()
 {
   return result_->get_test_count();
 }
 
-size_t TestingFixture::get_skip_count()
+unsigned int TestingFixture::get_skip_count()
 {
   return result_->get_skipped_count();
 }
@@ -154,7 +154,7 @@ const String& TestingFixture::get_output()
   return output_->get_output();
 }
 
-size_t TestingFixture::get_run_count()
+unsigned int TestingFixture::get_run_count()
 {
   return result_->get_run_count();
 }

--- a/src/test/TestingFixture.cpp
+++ b/src/test/TestingFixture.cpp
@@ -167,7 +167,7 @@ void TestingFixture::line_executed_after_check()
 void TestingFixture::check_test_fails_with_proper_test_location(
     const char* text,
     const char* file,
-    size_t line
+    int line
 )
 {
   if (get_failure_count() != 1) {

--- a/src/test/test.c.cpp
+++ b/src/test/test.c.cpp
@@ -7,7 +7,7 @@ void mutiny_check_equal_bool(
     bool actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_equals(
@@ -26,7 +26,7 @@ void mutiny_check_equal_int(
     int actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_intmax_equal(
@@ -44,7 +44,7 @@ void mutiny_check_equal_uint(
     unsigned int actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_uintmax_equal(
@@ -62,7 +62,7 @@ void mutiny_check_equal_long(
     long actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_intmax_equal(
@@ -80,7 +80,7 @@ void mutiny_check_equal_ulong(
     unsigned long actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_uintmax_equal(
@@ -98,7 +98,7 @@ void mutiny_check_equal_longlong(
     long long actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_intmax_equal(
@@ -116,7 +116,7 @@ void mutiny_check_equal_ulonglong(
     unsigned long long actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_uintmax_equal(
@@ -135,7 +135,7 @@ void mutiny_check_equal_double(
     double threshold,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   if (!mu::tiny::test::approx_equal(expected, actual, threshold)) {
@@ -158,7 +158,7 @@ void mutiny_check_equal_char(
     char actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_equals(
@@ -177,7 +177,7 @@ void mutiny_check_equal_ubyte(
     unsigned char actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_equals(
@@ -196,7 +196,7 @@ void mutiny_check_equal_sbyte(
     signed char actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_equals(
@@ -215,7 +215,7 @@ void mutiny_check_equal_string(
     const char* actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_cstr_equal(
@@ -233,7 +233,7 @@ void mutiny_check_equal_pointer(
     const void* actual,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_pointers_equal(
@@ -252,7 +252,7 @@ void mutiny_check_equal_memcmp(
     size_t size,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_binary_equal(
@@ -266,7 +266,11 @@ void mutiny_check_equal_memcmp(
   );
 }
 
-void mutiny_fail(const char* text, const char* file_name, int line_number)
+void mutiny_fail(
+    const char* text,
+    const char* file_name,
+    int_least32_t line_number
+)
 {
   mu::tiny::test::Shell::get_current()->fail(
       text,
@@ -281,7 +285,7 @@ void mutiny_check(
     const char* condition_string,
     const char* text,
     const char* file_name,
-    int line_number
+    int_least32_t line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_true(

--- a/src/test/test.c.cpp
+++ b/src/test/test.c.cpp
@@ -7,7 +7,7 @@ void mutiny_check_equal_bool(
     bool actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_equals(
@@ -26,7 +26,7 @@ void mutiny_check_equal_int(
     int actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_intmax_equal(
@@ -44,7 +44,7 @@ void mutiny_check_equal_uint(
     unsigned int actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_uintmax_equal(
@@ -62,7 +62,7 @@ void mutiny_check_equal_long(
     long actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_intmax_equal(
@@ -80,7 +80,7 @@ void mutiny_check_equal_ulong(
     unsigned long actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_uintmax_equal(
@@ -98,7 +98,7 @@ void mutiny_check_equal_longlong(
     long long actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_intmax_equal(
@@ -116,7 +116,7 @@ void mutiny_check_equal_ulonglong(
     unsigned long long actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_uintmax_equal(
@@ -135,7 +135,7 @@ void mutiny_check_equal_double(
     double threshold,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   if (!mu::tiny::test::approx_equal(expected, actual, threshold)) {
@@ -158,7 +158,7 @@ void mutiny_check_equal_char(
     char actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_equals(
@@ -177,7 +177,7 @@ void mutiny_check_equal_ubyte(
     unsigned char actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_equals(
@@ -196,7 +196,7 @@ void mutiny_check_equal_sbyte(
     signed char actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_equals(
@@ -215,7 +215,7 @@ void mutiny_check_equal_string(
     const char* actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_cstr_equal(
@@ -233,7 +233,7 @@ void mutiny_check_equal_pointer(
     const void* actual,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_pointers_equal(
@@ -252,7 +252,7 @@ void mutiny_check_equal_memcmp(
     size_t size,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_binary_equal(
@@ -266,7 +266,7 @@ void mutiny_check_equal_memcmp(
   );
 }
 
-void mutiny_fail(const char* text, const char* file_name, size_t line_number)
+void mutiny_fail(const char* text, const char* file_name, int line_number)
 {
   mu::tiny::test::Shell::get_current()->fail(
       text,
@@ -281,7 +281,7 @@ void mutiny_check(
     const char* condition_string,
     const char* text,
     const char* file_name,
-    size_t line_number
+    int line_number
 )
 {
   mu::tiny::test::Shell::get_current()->assert_true(

--- a/tests/src/CommandLineArguments.test.cpp
+++ b/tests/src/CommandLineArguments.test.cpp
@@ -89,7 +89,7 @@ TEST(CommandLineArguments, repeatSet)
   int argc = 2;
   const char* argv[] = { "tests.exe", "-r3" };
   CHECK(new_argument_parser(argc, argv));
-  CHECK_EQUAL(size_t{ 3 }, args->get_repeat_count());
+  CHECK_EQUAL(3U, args->get_repeat_count());
 }
 
 TEST(CommandLineArguments, repeatSetDifferentParameter)
@@ -97,7 +97,7 @@ TEST(CommandLineArguments, repeatSetDifferentParameter)
   int argc = 3;
   const char* argv[] = { "tests.exe", "-r", "4" };
   CHECK(new_argument_parser(argc, argv));
-  CHECK_EQUAL(size_t{ 4 }, args->get_repeat_count());
+  CHECK_EQUAL(4U, args->get_repeat_count());
 }
 
 TEST(CommandLineArguments, repeatSetDefaultsToTwoAndShuffleDisabled)
@@ -105,7 +105,7 @@ TEST(CommandLineArguments, repeatSetDefaultsToTwoAndShuffleDisabled)
   int argc = 2;
   const char* argv[] = { "tests.exe", "-r" };
   CHECK(new_argument_parser(argc, argv));
-  CHECK_EQUAL(size_t{ 2 }, args->get_repeat_count());
+  CHECK_EQUAL(2U, args->get_repeat_count());
 }
 
 TEST(CommandLineArguments, reverseEnabled)
@@ -137,7 +137,7 @@ TEST(CommandLineArguments, shuffleWithSeedZeroIsOk)
   int argc = 2;
   const char* argv[] = { "tests.exe", "-s0" };
   CHECK(!new_argument_parser(argc, argv));
-  CHECK_EQUAL(size_t{ 0 }, args->get_shuffle_seed());
+  CHECK_EQUAL(0U, args->get_shuffle_seed());
 }
 
 TEST(CommandLineArguments, shuffleEnabledSpecificSeedCase1)
@@ -145,7 +145,7 @@ TEST(CommandLineArguments, shuffleEnabledSpecificSeedCase1)
   int argc = 2;
   const char* argv[] = { "tests.exe", "-s999" };
   CHECK(new_argument_parser(argc, argv));
-  CHECK_EQUAL(size_t{ 999 }, args->get_shuffle_seed());
+  CHECK_EQUAL(999U, args->get_shuffle_seed());
 }
 
 TEST(CommandLineArguments, shuffleEnabledSpecificSeedCase2)
@@ -153,7 +153,7 @@ TEST(CommandLineArguments, shuffleEnabledSpecificSeedCase2)
   int argc = 2;
   const char* argv[] = { "tests.exe", "-s 888" };
   CHECK(new_argument_parser(argc, argv));
-  CHECK_EQUAL(size_t{ 888 }, args->get_shuffle_seed());
+  CHECK_EQUAL(888U, args->get_shuffle_seed());
 }
 
 TEST(CommandLineArguments, shuffleEnabledSpecificSeedCase3)
@@ -161,7 +161,7 @@ TEST(CommandLineArguments, shuffleEnabledSpecificSeedCase3)
   int argc = 3;
   const char* argv[] = { "tests.exe", "-s", "777" };
   CHECK(new_argument_parser(argc, argv));
-  CHECK_EQUAL(size_t{ 777 }, args->get_shuffle_seed());
+  CHECK_EQUAL(777U, args->get_shuffle_seed());
 }
 
 TEST(CommandLineArguments, shuffleBeforeDoesNotDisturbOtherSwitch)
@@ -507,7 +507,7 @@ TEST(CommandLineArguments, checkDefaultArguments)
   const char* argv[] = { "tests.exe" };
   CHECK(new_argument_parser(argc, argv));
   CHECK(!args->is_verbose());
-  CHECK_EQUAL(size_t{ 1 }, args->get_repeat_count());
+  CHECK_EQUAL(1U, args->get_repeat_count());
   CHECK(nullptr == args->get_group_filters());
   CHECK(nullptr == args->get_name_filters());
   CHECK(!args->is_crashing_on_fail());

--- a/tests/src/CommandLineTestRunner.test.cpp
+++ b/tests/src/CommandLineTestRunner.test.cpp
@@ -77,7 +77,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      size_t line_number
+      int line_number
   )
     : SkippedShell(group_name, test_name, file_name, line_number)
   {

--- a/tests/src/CommandLineTestRunner.test.cpp
+++ b/tests/src/CommandLineTestRunner.test.cpp
@@ -77,7 +77,7 @@ public:
       const char* group_name,
       const char* test_name,
       const char* file_name,
-      int line_number
+      int_least32_t line_number
   )
     : SkippedShell(group_name, test_name, file_name, line_number)
   {

--- a/tests/src/CompositeOutput.test.cpp
+++ b/tests/src/CompositeOutput.test.cpp
@@ -141,11 +141,17 @@ TEST(CompositeOutput, printLong)
   STRCMP_CONTAINS("42", runner->console->get_output().c_str());
 }
 
-TEST(CompositeOutput, printSizeT)
+TEST(CompositeOutput, printInt)
 {
   runner->console->flush();
-  size_t n = 7;
-  runner->composite->print(n);
+  runner->composite->print(7);
+  STRCMP_CONTAINS("7", runner->console->get_output().c_str());
+}
+
+TEST(CompositeOutput, printUnsigned)
+{
+  runner->console->flush();
+  runner->composite->print(7U);
   STRCMP_CONTAINS("7", runner->console->get_output().c_str());
 }
 

--- a/tests/src/CompositeOutput.test.cpp
+++ b/tests/src/CompositeOutput.test.cpp
@@ -158,7 +158,7 @@ TEST(CompositeOutput, printUnsigned)
 TEST(CompositeOutput, printDouble)
 {
   runner->console->flush();
-  runner->composite->print_double(2.5);
+  runner->composite->print(2.5);
   STRCMP_CONTAINS("2.5", runner->console->get_output().c_str());
 }
 

--- a/tests/src/ExpectFailTestShell.test.cpp
+++ b/tests/src/ExpectFailTestShell.test.cpp
@@ -73,5 +73,5 @@ TEST(ExpectFailShell, fourArgConstructor_setsGroupTestFileAndLine)
   STRCMP_EQUAL("MyGroup", shell.get_group());
   STRCMP_EQUAL("MyTest", shell.get_name());
   STRCMP_EQUAL("myfile.cpp", shell.get_file());
-  CHECK_EQUAL(size_t{ 42 }, shell.get_line_number());
+  CHECK_EQUAL(42, shell.get_line_number());
 }

--- a/tests/src/ExpectFailTestShell.test.cpp
+++ b/tests/src/ExpectFailTestShell.test.cpp
@@ -28,8 +28,8 @@ TEST(ExpectFailShell, innerTestFails_outerCountsRunNotFailure)
   fixture.add_test(&shell);
   fixture.run_all_tests();
   // 2 runs: fixture's built-in genTest_ + shell
-  CHECK_EQUAL(size_t{ 2 }, fixture.get_run_count());
-  CHECK_EQUAL(size_t{ 0 }, fixture.get_failure_count());
+  CHECK_EQUAL(2U, fixture.get_run_count());
+  CHECK_EQUAL(0U, fixture.get_failure_count());
 }
 
 TEST(ExpectFailShell, innerTestPasses_outerCountsRunAndFailure)
@@ -38,8 +38,8 @@ TEST(ExpectFailShell, innerTestPasses_outerCountsRunAndFailure)
   fixture.add_test(&shell);
   fixture.run_all_tests();
   // 2 runs: fixture's built-in genTest_ + shell
-  CHECK_EQUAL(size_t{ 2 }, fixture.get_run_count());
-  CHECK_EQUAL(size_t{ 1 }, fixture.get_failure_count());
+  CHECK_EQUAL(2U, fixture.get_run_count());
+  CHECK_EQUAL(1U, fixture.get_failure_count());
 }
 
 TEST(ExpectFailShell, willRun_alwaysReturnsTrue)

--- a/tests/src/JUnitOutput.test.cpp
+++ b/tests/src/JUnitOutput.test.cpp
@@ -230,7 +230,7 @@ public:
     return *this;
   }
 
-  JUnitTestOutputTestRunner& on_line(int line_number)
+  JUnitTestOutputTestRunner& on_line(int_least32_t line_number)
   {
     if (current_test_ != nullptr) {
       current_test_->set_line_number(line_number);
@@ -296,7 +296,7 @@ public:
   JUnitTestOutputTestRunner& that_fails(
       const char* message,
       const char* file,
-      int line
+      int_least32_t line
   )
   {
     test_failure_ =

--- a/tests/src/JUnitOutput.test.cpp
+++ b/tests/src/JUnitOutput.test.cpp
@@ -230,7 +230,7 @@ public:
     return *this;
   }
 
-  JUnitTestOutputTestRunner& on_line(size_t line_number)
+  JUnitTestOutputTestRunner& on_line(int line_number)
   {
     if (current_test_ != nullptr) {
       current_test_->set_line_number(line_number);
@@ -296,7 +296,7 @@ public:
   JUnitTestOutputTestRunner& that_fails(
       const char* message,
       const char* file,
-      size_t line
+      int line
   )
   {
     test_failure_ =

--- a/tests/src/MockFailureReporter.cpp
+++ b/tests/src/MockFailureReporter.cpp
@@ -95,7 +95,7 @@ void check_expected_mock_failure_location(
   );
 }
 
-void check_no_mock_failure_location(const char* file, int line)
+void check_no_mock_failure_location(const char* file, int_least32_t line)
 {
   if (!mock_failure_string().empty()) {
     mu::tiny::String error = "Unexpected mock failure:\n";

--- a/tests/src/MockFailureReporter.cpp
+++ b/tests/src/MockFailureReporter.cpp
@@ -69,7 +69,7 @@ void clear_mock_failure()
 void check_expected_mock_failure_string_location(
     const mu::tiny::String& expected_string,
     const char* file,
-    size_t line
+    int line
 )
 {
   mu::tiny::String actual_failure_string = mock_failure_string();
@@ -87,7 +87,7 @@ void check_expected_mock_failure_string_location(
 void check_expected_mock_failure_location(
     const mu::tiny::mock::Failure& expected_failure,
     const char* file,
-    size_t line
+    int line
 )
 {
   check_expected_mock_failure_string_location(
@@ -95,7 +95,7 @@ void check_expected_mock_failure_location(
   );
 }
 
-void check_no_mock_failure_location(const char* file, size_t line)
+void check_no_mock_failure_location(const char* file, int line)
 {
   if (!mock_failure_string().empty()) {
     mu::tiny::String error = "Unexpected mock failure:\n";

--- a/tests/src/MockFailureReporter.cpp
+++ b/tests/src/MockFailureReporter.cpp
@@ -69,7 +69,7 @@ void clear_mock_failure()
 void check_expected_mock_failure_string_location(
     const mu::tiny::String& expected_string,
     const char* file,
-    int line
+    int_least32_t line
 )
 {
   mu::tiny::String actual_failure_string = mock_failure_string();
@@ -87,7 +87,7 @@ void check_expected_mock_failure_string_location(
 void check_expected_mock_failure_location(
     const mu::tiny::mock::Failure& expected_failure,
     const char* file,
-    int line
+    int_least32_t line
 )
 {
   check_expected_mock_failure_string_location(

--- a/tests/src/MockFailureReporter.hpp
+++ b/tests/src/MockFailureReporter.hpp
@@ -44,12 +44,12 @@ void clear_mock_failure();
 void check_expected_mock_failure_string_location(
     const mu::tiny::String& expected_string,
     const char* file,
-    int line
+    int_least32_t line
 );
 void check_expected_mock_failure_location(
     const mu::tiny::mock::Failure& expected_failure,
     const char* file,
-    int line
+    int_least32_t line
 );
 void check_no_mock_failure_location(const char* file, int_least32_t line);
 

--- a/tests/src/MockFailureReporter.hpp
+++ b/tests/src/MockFailureReporter.hpp
@@ -5,6 +5,8 @@
 
 #include "mu/tiny/mock.hpp"
 
+#include <stdint.h>
+
 #define CHECK_EXPECTED_MOCK_FAILURE(expectedFailure)                           \
   check_expected_mock_failure_location(expectedFailure, __FILE__, __LINE__)
 #define CHECK_EXPECTED_MOCK_FAILURE_STRING(expectedString)                     \
@@ -49,6 +51,6 @@ void check_expected_mock_failure_location(
     const char* file,
     int line
 );
-void check_no_mock_failure_location(const char* file, int line);
+void check_no_mock_failure_location(const char* file, int_least32_t line);
 
 #endif

--- a/tests/src/MockFailureReporter.hpp
+++ b/tests/src/MockFailureReporter.hpp
@@ -42,13 +42,13 @@ void clear_mock_failure();
 void check_expected_mock_failure_string_location(
     const mu::tiny::String& expected_string,
     const char* file,
-    size_t line
+    int line
 );
 void check_expected_mock_failure_location(
     const mu::tiny::mock::Failure& expected_failure,
     const char* file,
-    size_t line
+    int line
 );
-void check_no_mock_failure_location(const char* file, size_t line);
+void check_no_mock_failure_location(const char* file, int line);
 
 #endif

--- a/tests/src/MockSupportPlugin.test.cpp
+++ b/tests/src/MockSupportPlugin.test.cpp
@@ -150,7 +150,7 @@ TEST(SupportPlugin, preTestActionWillEnableMultipleComparatorsToTheGlobalMockSup
   );
 
   mock().check_expectations();
-  CHECK_EQUAL(size_t{ 0 }, result->get_failure_count());
+  CHECK_EQUAL(0U, result->get_failure_count());
 
   plugin.clear();
 }

--- a/tests/src/Ordered.test.cpp
+++ b/tests/src/Ordered.test.cpp
@@ -80,7 +80,7 @@ TEST(Ordered, TestInstallerSetsFields)
   STRCMP_EQUAL("testgroup", ordered_test.get_group());
   STRCMP_EQUAL("testname", ordered_test.get_name());
   STRCMP_EQUAL("this.cpp", ordered_test.get_file());
-  CHECK_EQUAL(size_t{ 10 }, ordered_test.get_line_number());
+  CHECK_EQUAL(10, ordered_test.get_line_number());
   CHECK_EQUAL(5, ordered_test.get_level());
 }
 

--- a/tests/src/Shell.test.cpp
+++ b/tests/src/Shell.test.cpp
@@ -199,14 +199,14 @@ TEST(Shell, FailWillIncreaseTheAmountOfChecks)
 {
   fixture.set_test_function(fail_method);
   fixture.run_all_tests();
-  CHECK_EQUAL(size_t{ 1 }, fixture.get_check_count());
+  CHECK_EQUAL(1U, fixture.get_check_count());
 }
 
 TEST(Shell, PassedCheckEqualWillIncreaseTheAmountOfChecks)
 {
   fixture.set_test_function(passing_check_equal_test_method);
   fixture.run_all_tests();
-  CHECK_EQUAL(size_t{ 1 }, fixture.get_check_count());
+  CHECK_EQUAL(1U, fixture.get_check_count());
 }
 
 TEST(Shell, SetTestFunctionExecFunctionOverloadRunsTheFunction)
@@ -227,7 +227,7 @@ TEST(Shell, MacrosUsedInSetup)
   fixture.set_setup(fail_method);
   fixture.set_test_function(simple_passing_method);
   fixture.run_all_tests();
-  CHECK_EQUAL(size_t{ 1 }, fixture.get_failure_count());
+  CHECK_EQUAL(1U, fixture.get_failure_count());
 }
 
 TEST(Shell, MacrosUsedInTearDown)
@@ -235,14 +235,14 @@ TEST(Shell, MacrosUsedInTearDown)
   fixture.set_teardown(fail_method);
   fixture.set_test_function(simple_passing_method);
   fixture.run_all_tests();
-  CHECK_EQUAL(size_t{ 1 }, fixture.get_failure_count());
+  CHECK_EQUAL(1U, fixture.get_failure_count());
 }
 
 TEST(Shell, ExitLeavesQuietly)
 {
   fixture.set_test_function(exit_test_method);
   fixture.run_all_tests();
-  CHECK_EQUAL(size_t{ 0 }, fixture.get_failure_count());
+  CHECK_EQUAL(0U, fixture.get_failure_count());
 }
 
 TEST(Shell, FailWillNotCrashIfNotEnabled)
@@ -254,7 +254,7 @@ TEST(Shell, FailWillNotCrashIfNotEnabled)
   fixture.run_all_tests();
 
   CHECK(!mutiny_has_crashed);
-  CHECK_EQUAL(size_t{ 1 }, fixture.get_failure_count());
+  CHECK_EQUAL(1U, fixture.get_failure_count());
 
   mu::tiny::test::Shell::reset_crash_method();
 }
@@ -280,7 +280,7 @@ TEST(Shell, TeardownCalledAfterTestFailure)
   fixture.set_teardown(teardown_method);
   fixture.set_test_function(fail_method);
   fixture.run_all_tests();
-  CHECK_EQUAL(size_t{ 1 }, fixture.get_failure_count());
+  CHECK_EQUAL(1U, fixture.get_failure_count());
   CHECK_EQUAL(1, teardown_called);
 }
 
@@ -290,7 +290,7 @@ TEST(Shell, TestStopsAfterTestFailure)
   fixture.set_test_function(stop_after_failure_method);
   fixture.run_all_tests();
   CHECK(fixture.has_test_failed());
-  CHECK_EQUAL(size_t{ 1 }, fixture.get_failure_count());
+  CHECK_EQUAL(1U, fixture.get_failure_count());
   CHECK_EQUAL(0, stop_after_failure);
 }
 
@@ -545,7 +545,7 @@ TEST(Shell, this_test_covers_the_TestShell_createTest_and_Utest_testBody_methods
   DefaultTestShell shell;
   fixture.add_test(&shell);
   fixture.run_all_tests();
-  CHECK_EQUAL(size_t{ 2 }, fixture.get_test_count());
+  CHECK_EQUAL(2U, fixture.get_test_count());
 }
 
 TEST(Shell, getSkipCountReturnsNumberOfSkippedTests)
@@ -553,7 +553,7 @@ TEST(Shell, getSkipCountReturnsNumberOfSkippedTests)
   mu::tiny::test::SkippedShell skipped;
   fixture.add_test(&skipped);
   fixture.run_all_tests();
-  CHECK_EQUAL(size_t{ 1 }, fixture.get_skip_count());
+  CHECK_EQUAL(1U, fixture.get_skip_count());
 }
 
 TEST(Shell, checkTestFailsWithProperTestLocationFailsWhenFailureCountIsNotOne)

--- a/tests/src/String.test.cpp
+++ b/tests/src/String.test.cpp
@@ -646,23 +646,6 @@ TEST(String, StrNCmp_s1_and_s2_empty)
   CHECK_EQUAL(0, result);
 }
 
-TEST(String, strtol)
-{
-  char max_short_str[] = "32767";
-  char min_short_str[] = "-32768";
-
-  CHECK(12345 == mu::tiny::strtol("012345"));
-  CHECK(6789 == mu::tiny::strtol("6789"));
-  CHECK(12345 == mu::tiny::strtol("12345/"));
-  CHECK(12345 == mu::tiny::strtol("12345:"));
-  CHECK(-12345 == mu::tiny::strtol("-12345"));
-  CHECK(123 == mu::tiny::strtol("\t \r\n123"));
-  CHECK(123 == mu::tiny::strtol("123-foo"));
-  CHECK(0 == mu::tiny::strtol("-foo"));
-  CHECK(-32768 == mu::tiny::strtol(min_short_str));
-  CHECK(32767 == mu::tiny::strtol(max_short_str));
-}
-
 TEST(String, strtoul)
 {
   char max_short_str[] = "65535";

--- a/tests/src/TapOutput.test.cpp
+++ b/tests/src/TapOutput.test.cpp
@@ -159,7 +159,7 @@ public:
   TapTestOutputTestRunner& that_fails(
       const char* message,
       const char* file,
-      int line
+      int_least32_t line
   )
   {
     test_failure_ =

--- a/tests/src/TapOutput.test.cpp
+++ b/tests/src/TapOutput.test.cpp
@@ -159,7 +159,7 @@ public:
   TapTestOutputTestRunner& that_fails(
       const char* message,
       const char* file,
-      size_t line
+      int line
   )
   {
     test_failure_ =

--- a/tests/src/TestFailure.test.cpp
+++ b/tests/src/TestFailure.test.cpp
@@ -39,7 +39,7 @@ TEST(Failure, GetTestFileAndLineFromFailure)
       test, fail_file_name, fail_line_number, "the failure message"
   );
   STRCMP_EQUAL(fail_file_name, f1.get_test_file_name().c_str());
-  CHECK_EQUAL(size_t{ 1 }, f1.get_test_line_number());
+  CHECK_EQUAL(1, f1.get_test_line_number());
 }
 
 TEST(Failure, EqualsFailureWithText)

--- a/tests/src/TestOutput.test.cpp
+++ b/tests/src/TestOutput.test.cpp
@@ -64,15 +64,13 @@ TEST(Output, PrintConstCharStar)
 
 TEST(Output, PrintLong)
 {
-  long number = 1234;
-  printer->print(number);
+  printer->print(1234L);
   STRCMP_EQUAL("1234", mock->get_output().c_str());
 }
 
-TEST(Output, PrintSize)
+TEST(Output, PrintUnsigned)
 {
-  size_t ten = 10;
-  printer->print(ten);
+  printer->print(10U);
   STRCMP_EQUAL("10", mock->get_output().c_str());
 }
 

--- a/tests/src/TestOutput.test.cpp
+++ b/tests/src/TestOutput.test.cpp
@@ -76,7 +76,7 @@ TEST(Output, PrintUnsigned)
 
 TEST(Output, PrintDouble)
 {
-  printer->print_double(12.34);
+  printer->print(12.34);
   STRCMP_EQUAL("12.34", mock->get_output().c_str());
 }
 


### PR DESCRIPTION
## Description
Replace `size_t` with semantically appropriate integer types throughout the framework:

- **Line numbers**: `size_t` → `int` (prior PR) → `int_least32_t`. `size_t` is for object sizes/memory offsets. `int` is the type of `__LINE__`, but is only guaranteed 16 bits — `__LINE__` can reach `INT_MAX` (2147483647), requiring 32 bits. `int_least32_t` is the smallest signed type guaranteed to hold any valid line number.
- **Test/check/skip/run counts**: `size_t` → `unsigned int`. These are plain counts, not memory quantities.
- **String substring counts** in `StringCollection`: `size_t` → `unsigned int`.
- **`CircularBuffer` example**: `int` → `size_t` for capacity and index fields, which are genuine sizes/offsets into an allocated buffer.

Adds `#include <stdint.h>` to public headers that now expose `int_least32_t`.

## Related Issues
Fixes # (issue number)

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Manual Verification (Optional)
If you have verified this change on hardware or a simulator not covered by CI (e.g., a specific ARM target), please describe it here:
- **Target:**
- **Result:**

## Checklist
- [ ] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [ ] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.