### PR TITLE
Let ClangCL preset auto-detect the Visual Studio generator

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -57,7 +57,6 @@
     {
       "name": "ClangCL",
       "inherits": ["MSVC"],
-      "generator": "Visual Studio 17 2022",
       "toolset": "ClangCL"
     },
     {


### PR DESCRIPTION
## Summary

- `windows-latest` now points to `windows-2025`, which ships Visual Studio 18 (2025)
- The `ClangCL` preset had `"generator": "Visual Studio 17 2022"` hardcoded, causing CMake to fail with *could not find any instance of Visual Studio*
- The `MSVC` preset never specified a generator and works fine because CMake auto-detects whatever VS version is installed
- Remove the explicit generator from `ClangCL` so it does the same