### PR TITLE
Fix OOB reads and memory leak found by upstream PRs

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -129,7 +129,8 @@
       "name": "asan",
       "inherits": ["Clang"],
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "MUTINY_USE_STD_STRING": false
       },
       "environment": {
         "CFLAGS": "-fsanitize=address -fno-omit-frame-pointer",

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -323,7 +323,7 @@ void String::resize(size_t new_size)
 
 String String::substr(size_t begin_pos, size_t amount) const
 {
-  if (begin_pos > size() - 1) {
+  if (begin_pos >= size()) {
     return "";
   }
 

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -5,6 +5,9 @@
 
 #if MUTINY_USE_STD_CPP_LIB
 #include <string>
+#if MUTINY_HAVE_EXCEPTIONS
+#include <stdexcept>
+#endif
 #endif
 
 #if MUTINY_USE_STD_STRING
@@ -323,7 +326,14 @@ void String::resize(size_t new_size)
 
 String String::substr(size_t begin_pos, size_t amount) const
 {
-  if (begin_pos >= size()) {
+  if (begin_pos > size()) {
+#if MUTINY_HAVE_EXCEPTIONS && MUTINY_USE_STD_CPP_LIB
+    throw std::out_of_range("String::substr");
+#else
+    return "";
+#endif
+  }
+  if (begin_pos == size()) {
     return "";
   }
 

--- a/src/mock/CheckedActualCall.cpp
+++ b/src/mock/CheckedActualCall.cpp
@@ -114,9 +114,9 @@ void CheckedActualCall::discard_currently_matching_expectations()
   potentially_matching_expectations_.only_keep_unmatching_expectations();
 }
 
-void CheckedActualCall::set_name_and_check(StringView name)
+void CheckedActualCall::set_name_and_check(String name)
 {
-  function_name_ = String(name.data(), name.size());
+  function_name_ = static_cast<String&&>(name);
   set_state(MutinyActualCallState::in_progress);
 
   potentially_matching_expectations_.only_keep_expectations_related_to(

--- a/src/mu/tiny/mock/CheckedActualCall.hpp
+++ b/src/mu/tiny/mock/CheckedActualCall.hpp
@@ -45,7 +45,7 @@ public:
   virtual void check_expectations();
 
   virtual void set_mock_failure_reporter(FailureReporter* reporter);
-  void set_name_and_check(StringView name);
+  void set_name_and_check(String name);
 
 protected:
   const String& get_name() const;

--- a/src/test/Failure.cpp
+++ b/src/test/Failure.cpp
@@ -279,13 +279,22 @@ CheckEqualFailure::CheckEqualFailure(
 
   message_ += create_but_was_string(printable_expected, printable_actual);
 
+  const size_t comparison_length =
+      actual.size() < expected.size() ? actual.size() : expected.size();
   size_t fail_start;
-  for (fail_start = 0; actual[fail_start] == expected[fail_start];
+  for (fail_start = 0; fail_start < comparison_length &&
+                       actual[fail_start] == expected[fail_start];
        fail_start++) {
   }
+  const size_t printable_comparison_length =
+      printable_actual.size() < printable_expected.size()
+          ? printable_actual.size()
+          : printable_expected.size();
   size_t fail_start_printable;
-  for (fail_start_printable = 0; printable_actual[fail_start_printable] ==
-                                 printable_expected[fail_start_printable];
+  for (fail_start_printable = 0;
+       fail_start_printable < printable_comparison_length &&
+       printable_actual[fail_start_printable] ==
+           printable_expected[fail_start_printable];
        fail_start_printable++) {
   }
   message_ += create_difference_at_pos_string(

--- a/tests/src/String.test.cpp
+++ b/tests/src/String.test.cpp
@@ -199,6 +199,14 @@ TEST(String, subStringFromEmptyString)
   STRCMP_EQUAL("", str.substr(0, 1).c_str());
 }
 
+#if !MUTINY_USE_STD_CPP_LIB
+TEST(String, subStringFromEmptyStringWithNonZeroPos)
+{
+  mu::tiny::String str("");
+  STRCMP_EQUAL("", str.substr(1, 1).c_str());
+}
+#endif
+
 TEST(String, subStringFromSmallString)
 {
   mu::tiny::String str("H");

--- a/tests/src/String.test.cpp
+++ b/tests/src/String.test.cpp
@@ -199,13 +199,15 @@ TEST(String, subStringFromEmptyString)
   STRCMP_EQUAL("", str.substr(0, 1).c_str());
 }
 
-#if !MUTINY_USE_STD_CPP_LIB
 TEST(String, subStringFromEmptyStringWithNonZeroPos)
 {
   mu::tiny::String str("");
+#if MUTINY_HAVE_EXCEPTIONS && MUTINY_USE_STD_CPP_LIB
+  CHECK_THROWS(std::out_of_range, (void)str.substr(1, 1));
+#elif !MUTINY_USE_STD_STRING
   STRCMP_EQUAL("", str.substr(1, 1).c_str());
-}
 #endif
+}
 
 TEST(String, subStringFromSmallString)
 {

--- a/tests/src/TestFailure.test.cpp
+++ b/tests/src/TestFailure.test.cpp
@@ -107,6 +107,18 @@ TEST(Failure, CheckEqualFailure)
   );
 }
 
+TEST(Failure, CheckEqualFailureIdenticalRepresentations)
+{
+  mu::tiny::test::CheckEqualFailure f(
+      test, fail_file_name, fail_line_number, "1", "1", ""
+  );
+  CHECK(
+      mu::tiny::string_contains(
+          f.get_message(), "difference starts at position 1"
+      )
+  );
+}
+
 TEST(Failure, CheckFailure)
 {
   mu::tiny::test::CheckFailure f(


### PR DESCRIPTION
## Summary

- Fix unsigned underflow in `String::substr()` on empty strings (mirrors cpputest#1889)
- Fix unbounded difference scans in `CheckEqualFailure` (mirrors cpputest#1890)
- Fix `String` leak in `CheckedActualCall` when `longjmp` unwinds the stack
- Move `MUTINY_USE_STD_CPP_LIB` to `cacheVariables` in the `asan` preset
- Make `String::substr()` throw `std::out_of_range` when exceptions are available, narrowing the behavioral divergence with `std::string`