### PR TITLE
Trigger release workflow on published, not just created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 
 "on":
   release:
-    types: [created]
+    types: [created, published]
 
 jobs:
   source-archive:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 
 "on":
   release:
-    types: [created, published]
+    types: [published]
 
 jobs:
   source-archive:


### PR DESCRIPTION
## Description
Publishing v0.8.0 from a draft release fired GitHub's `published` event, not `created`, so `release.yml`'s Source Archive job never ran — the tarball/zip had to be attached by hand after the fact.

`created` fires on *any* new release, including drafts. `published` fires on any new release that is *not* a draft — covering both a direct (non-draft) release creation and a draft later transitioning to published, exactly once each. (A direct release creation fires both `created` and `published` simultaneously, so listening to both would run the job twice on the common path — `published` alone is the correct fix, not an addition.)

## Related Issues
N/A

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Manual Verification (Optional)
- **Target:** Reproduced the failure by creating v0.8.0 as a draft then publishing it — no `Release` workflow run fired for either event under the old `types: [created]` config. Manually ran the job's steps (`cmake --preset GNU`, `cpack --preset source`, `gh release upload`) to attach the missing assets.
- **Result:** N/A for this fix directly (can't re-trigger v0.8.0's release event), but the next release — direct or via draft — should fire the job exactly once.

## Checklist
- [ ] I have written/updated documentation in `docs/` for any user-facing changes.
- [x] My code follows the project's naming conventions (`mu::tiny` namespace, `INCLUDED_MU_TINY_` guards, `mutiny_` C-prefix).
- [ ] For new features, I have considered if a C-interface adapter (`.h` and `.c.cpp`) is required for parity.
- [x] I have reviewed the `CONTRIBUTING.md` file to ensure compliance with architectural guidelines.